### PR TITLE
Use rust-xdg for cache creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "tealdeer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14,6 +14,7 @@ dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -49,7 +50,7 @@ dependencies = [
  "curl-sys 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -61,7 +62,7 @@ dependencies = [
  "gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -116,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "kernel32-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -273,7 +274,7 @@ name = "thread-id"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -291,7 +292,7 @@ name = "time"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -322,7 +323,7 @@ name = "unreachable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "void 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -361,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "void"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -369,7 +370,7 @@ name = "walkdir"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -381,5 +382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "winapi-build"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xdg"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,18 @@ logging = ["env_logger"]
 dev = ["clippy"]
 
 [dependencies]
-ansi_term = "^0.7"
 log = "^0.3"
+xdg = "^2.0"
 tar = "^0.4"
-flate2 = "^0.2"
 curl = "^0.2"
-rustc-serialize = "^0.3"
-docopt = "^0.6"
 time = "^0.1"
+flate2 = "^0.2"
+docopt = "^0.6"
 walkdir = "^0.1"
-env_logger = { version = "^0.3", optional = true }
+ansi_term = "^0.7"
+rustc-serialize = "^0.3"
 clippy = {version = "~0.0.37", optional = true}
+env_logger = { version = "^0.3", optional = true }
 
 [dev-dependencies]
 tempdir = "^0.3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -49,7 +49,7 @@ impl Cache {
         // Otherwise, fall back to $XDG_CACHE_HOME/tealdeer.
         let xdg_dirs = match BaseDirectories::with_prefix("tealdeer") {
             Ok(dirs) => dirs,
-            Err(_) => return Err(CacheError("$HOME does not exist or is not defined.".into())),
+            Err(_) => return Err(CacheError("Could not determine XDG base directory.".into())),
         };
         Ok(xdg_dirs.get_cache_home())
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -47,7 +47,7 @@ impl Cache {
         };
 
         // Otherwise, fall back to $XDG_CACHE_HOME/tealdeer.
-        let xdg_dirs = match BaseDirectories::with_prefix("tealdeer") {
+        let xdg_dirs = match BaseDirectories::with_prefix(::NAME) {
             Ok(dirs) => dirs,
             Err(_) => return Err(CacheError("Could not determine XDG base directory.".into())),
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,10 @@
 use curl::ErrCode;
 
-
 #[derive(Debug)]
 pub enum TldrError {
     CacheError(String),
     UpdateError(String),
 }
-
 
 impl From<ErrCode> for TldrError {
     fn from(err: ErrCode) -> TldrError {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -7,7 +7,6 @@ use ansi_term::{Colour, ANSIStrings};
 use tokenizer::Tokenizer;
 use types::LineType;
 
-
 /// Provide formatting for {{ curly braces }} in ExampleCode lines
 fn format_braces(text: &str) -> String {
     let parts = text.split("{{").flat_map(|s| s.split("}}"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,12 @@
                                   wrong_self_convention, wrong_pub_self_convention))]
 
 #[macro_use] extern crate log;
-#[cfg(feature = "logging")]extern crate env_logger;
+#[cfg(feature = "logging")] extern crate env_logger;
 extern crate docopt;
 extern crate ansi_term;
 extern crate flate2;
 extern crate tar;
+extern crate xdg;
 extern crate curl;
 extern crate rustc_serialize;
 extern crate time;
@@ -52,7 +53,6 @@ use cache::Cache;
 use error::TldrError::{UpdateError, CacheError};
 use formatter::print_lines;
 use types::OsType;
-
 
 const NAME: &'static str = "tealdeer";
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -89,7 +89,6 @@ To render a local file (for testing):
 const ARCHIVE_URL: &'static str = "https://github.com/tldr-pages/tldr/archive/master.tar.gz";
 const MAX_CACHE_AGE: i64 = 2592000; // 30 days
 
-
 #[derive(Debug, RustcDecodable)]
 struct Args {
     arg_command: Option<String>,
@@ -101,7 +100,6 @@ struct Args {
     flag_update: bool,
     flag_clear_cache: bool,
 }
-
 
 /// Print page by path
 fn print_page(path: &Path) -> Result<(), String> {
@@ -117,7 +115,6 @@ fn print_page(path: &Path) -> Result<(), String> {
 
     Ok(())
 }
-
 
 /// Check the cache for freshness
 fn check_cache(args: &Args, cache: &Cache) {
@@ -139,7 +136,6 @@ fn check_cache(args: &Args, cache: &Cache) {
     };
 }
 
-
 #[cfg(feature = "logging")]
 fn init_log() {
     env_logger::init().unwrap();
@@ -147,7 +143,6 @@ fn init_log() {
 
 #[cfg(not(feature = "logging"))]
 fn init_log() { }
-
 
 #[cfg(target_os = "linux")]
 fn get_os() -> OsType { OsType::Linux }
@@ -158,9 +153,7 @@ fn get_os() -> OsType { OsType::OsX }
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn get_os() -> OsType { OsType::Other }
 
-
 fn main() {
-
     // Initialize logger
     init_log();
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -4,7 +4,6 @@ use std::io::BufRead;
 
 use types::LineType;
 
-
 #[derive(Debug)]
 pub struct Tokenizer<R: BufRead> {
     reader: R,
@@ -12,7 +11,6 @@ pub struct Tokenizer<R: BufRead> {
 }
 
 impl<R> Tokenizer<R> where R: BufRead {
-
     pub fn new(reader: R) -> Tokenizer<R> {
         Tokenizer {
             reader: reader,
@@ -29,5 +27,4 @@ impl<R> Tokenizer<R> where R: BufRead {
             Ok(_) => Some(LineType::from(&self.current_line[..])),
         }
     }
-
 }


### PR DESCRIPTION
Pretty small PR that closes #10.

I believe this PR also fixes a bug you might not of noticed, where if a user changed `$XDG_CACHE_HOME`, tealdeer would still create the cache under `~/.cache`. Correct me if I'm wrong though.

I've also gone through and removed the spaces like [you said](https://github.com/dbrgn/tealdeer/issues/10#issuecomment-211429317).