### PR TITLE
OS detection: Treat BSDs as "osx"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -199,12 +199,21 @@ fn get_os() -> OsType {
     OsType::Linux
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos",
+          target_os = "freebsd",
+          target_os = "netbsd",
+          target_os = "openbsd",
+          target_os = "dragonfly"))]
 fn get_os() -> OsType {
     OsType::OsX
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux",
+              target_os = "macos",
+              target_os = "freebsd",
+              target_os = "netbsd",
+              target_os = "openbsd",
+              target_os = "dragonfly")))]
 fn get_os() -> OsType {
     OsType::Other
 }


### PR DESCRIPTION
Since macOS is also a BSD under the hood, this will probably yield better results.