### PR TITLE
Add Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.md eol=lf
+*.expected eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,17 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "app_dirs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "assert_cli"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ole32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "skeptic"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +711,7 @@ name = "tealdeer"
 version = "1.1.0"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.174 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -693,11 +723,9 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "utime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -733,16 +761,6 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "time"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -889,6 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
 "checksum assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72342c21057a3cb5f7c2d849bf7999a83795434dd36d74fa8c24680581bd1930"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
@@ -935,6 +954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"
+"checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.39 (registry+https://github.com/rust-lang/crates.io-index)" = "278c1ad40a89aa1e741a1eed089a2f60b18fab8089c3139b542140fc7d674106"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
@@ -964,6 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+"checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 "checksum skeptic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4474d6da9593171bcb086890fc344a3a12783cb24e5b141f8a5d0e43561f4b6"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
@@ -973,7 +994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2ecc31b0351ea18b3fe11274b8db6e4d82bce861bbb22e6dbed40417902c65"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,9 @@ log = "0.4"
 serde = "1.0.21"
 serde_derive = "1.0.21"
 tar = "0.4.14"
-time = "0.1.38"
 toml = "0.4.6"
 walkdir = "2.0.1"
-xdg = "2.1.0"
+app_dirs = "1.2.1"
 
 [dev-dependencies]
 tempdir = "^0.3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,15 +3,12 @@ use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
 
-#[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
-
+use app_dirs::{get_app_root, AppDataType};
 use curl::easy::Easy as CurlEasy;
 use flate2::read::GzDecoder;
+use std::time::{Duration, SystemTime};
 use tar::Archive;
-use time;
 use walkdir::{DirEntry, WalkDir};
-use xdg::BaseDirectories;
 
 use error::TealdeerError::{self, CacheError, UpdateError};
 use types::OsType;
@@ -52,11 +49,10 @@ impl Cache {
         };
 
         // Otherwise, fall back to $XDG_CACHE_HOME/tealdeer.
-        let xdg_dirs = match BaseDirectories::with_prefix(::NAME) {
-            Ok(dirs) => dirs,
-            Err(_) => return Err(CacheError("Could not determine XDG base directory.".into())),
-        };
-        Ok(xdg_dirs.get_cache_home())
+        match get_app_root(AppDataType::UserCache, &::APP_INFO) {
+            Ok(dirs) => Ok(dirs),
+            Err(_) => Err(CacheError("Could not determine XDG base directory.".into())),
+        }
     }
 
     /// Download the archive
@@ -118,14 +114,14 @@ impl Cache {
         Ok(())
     }
 
-    #[cfg(unix)]
-    /// Return the number of seconds since the cache directory was last modified.
-    pub fn last_update(&self) -> Option<i64> {
+    /// Return the duration since the cache directory was last modified.
+    pub fn last_update(&self) -> Option<Duration> {
         if let Ok(cache_dir) = self.get_cache_dir() {
             if let Ok(metadata) = fs::metadata(cache_dir.join("tldr-master")) {
-                let mtime = metadata.mtime();
-                let now = time::now_utc().to_timespec();
-                return Some(now.sec - mtime);
+                if let Ok(mtime) = metadata.modified() {
+                    let now = SystemTime::now();
+                    return now.duration_since(mtime).ok();
+                };
             };
         };
         None

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,8 @@ use std::io::{Error as IoError, Read, Write};
 use std::path::PathBuf;
 
 use ansi_term::{Color, Style};
+use app_dirs::{get_app_root, AppDataType};
 use toml;
-use xdg::BaseDirectories;
 
 use error::TealdeerError::{self, ConfigError};
 
@@ -199,13 +199,12 @@ pub fn get_config_dir() -> Result<PathBuf, TealdeerError> {
     };
 
     // Otherwise, fall back to $XDG_CONFIG_HOME/tealdeer.
-    let xdg_dirs = match BaseDirectories::with_prefix(::NAME) {
-        Ok(dirs) => dirs,
-        Err(_) => {
-            return Err(ConfigError("Could not determine XDG base directory.".into()))
-        }
-    };
-    Ok(xdg_dirs.get_config_home())
+    match get_app_root(AppDataType::UserConfig, &::APP_INFO) {
+        Ok(dirs) => Ok(dirs),
+        Err(_) => Err(ConfigError(
+            "Could not determine XDG base directory.".into(),
+        )),
+    }
 }
 
 /// Return the path to the config file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,16 +46,15 @@
 #[macro_use]
 extern crate log;
 extern crate ansi_term;
+extern crate app_dirs;
 extern crate curl;
 extern crate docopt;
 #[cfg(feature = "logging")]
 extern crate env_logger;
 extern crate flate2;
 extern crate tar;
-extern crate time;
 extern crate toml;
 extern crate walkdir;
-extern crate xdg;
 #[macro_use]
 extern crate serde_derive;
 
@@ -63,6 +62,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process;
+use std::time::Duration;
 
 use ansi_term::Color;
 use docopt::Docopt;
@@ -74,6 +74,7 @@ mod formatter;
 mod tokenizer;
 mod types;
 
+use app_dirs::AppInfo;
 use cache::Cache;
 use config::{get_config_path, make_default_config, Config};
 use error::TealdeerError::{CacheError, ConfigError, UpdateError};
@@ -82,6 +83,10 @@ use tokenizer::Tokenizer;
 use types::OsType;
 
 const NAME: &str = "tealdeer";
+const APP_INFO: AppInfo = AppInfo {
+    name: NAME,
+    author: NAME,
+};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const USAGE: &str = "
 Usage:
@@ -117,7 +122,7 @@ To render a local file (for testing):
     $ tldr --render /path/to/file.md
 ";
 const ARCHIVE_URL: &str = "https://github.com/tldr-pages/tldr/archive/master.tar.gz";
-const MAX_CACHE_AGE: i64 = 2592000; // 30 days
+const MAX_CACHE_AGE: Duration = Duration::from_secs(2_592_000); // 30 days
 
 #[derive(Debug, Deserialize)]
 struct Args {
@@ -173,7 +178,7 @@ fn check_cache(args: &Args, cache: &Cache) {
                     Color::Red.paint(format!(
                         "Cache wasn't updated for more than {} days.\n\
                          You should probably run `tldr --update` soon.",
-                        MAX_CACHE_AGE / 24 / 3600
+                        MAX_CACHE_AGE.as_secs() / 24 / 3600
                     ))
                 );
             }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -156,11 +156,16 @@ fn test_show_config_path() {
         .assert()
         .with_args(&["--config-path"])
         .succeeds()
-        .stdout().contains(format!(
-            "Config path is: {}/config.toml",
-            testenv.config_dir.path().to_str().unwrap(),
-        ))
-        .unwrap();
+        .stdout()
+        .contains(format!(
+            "Config path is: {}",
+            testenv
+                .config_dir
+                .path()
+                .join("config.toml")
+                .to_str()
+                .unwrap(),
+        )).unwrap();
 }
 
 fn _test_correct_rendering(input_file: &str, filename: &str) {


### PR DESCRIPTION
This fixes #53 and unblocks #52 

The main change is removing the `xdg` crate and adding `app_dirs`, though it was also required to change the `last_update` on `Cache` to support Windows. The later change meant the `time` crate was no longer needed also.

I had some trouble with line endings breaking the tests which is why the `.gitattributes` file has been added, this seems to have stopped the failures from Travis at least.

One point that should be highlighted is that I believe this change will move the folder locations used for the cache and config directories on Mac. Previously it seems to have used `$HOME/.cache` and `$HOME/.config` but `app_dirs` uses `$HOME/Library/Caches/` and `$HOME/Library/Application Support/`.

I also want to point out that I have used `NAME` for both `name` and `author` in the `AppInfo`. I am not sure if having 'tealdeer' used for both of this is ideal or wanted, though `author` is only used for paths on Windows.

This probably needs more testing on Windows as I haven't had the chance to fully try it out yet. My main concern in this respect is I don't believe the Windows command prompt, or PowerShell, handle ANSI color codes.