### PR TITLE
Mention Void Linux Package in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ If you're an Arch Linux user, you can also install the package from the AUR:
 - [tealdeer](https://aur.archlinux.org/packages/tealdeer/)
 - [tealdeer-git](https://aur.archlinux.org/packages/tealdeer-git/)
 
+### Through xbps (Void Linux)
+
+If you're a Void Linux user, you can install the package using xbps:
+
+    $ xbps-install -Sy tealdeer
+
 ### From Homebrew (macOS)
 
  If you're a macOS user, you can install the package from the Homebrew with the following command:


### PR DESCRIPTION
My PR for packaging tealdeer on void was merged, so you can now easily install tealdeer on void: https://github.com/void-linux/void-packages/pull/4908