### PR TITLE
Add --auto-update flag to allow automatically updating the cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,13 +126,19 @@ fn check_cache(args: &Args, cache: &Cache) {
         match cache.last_update() {
             Some(ago) if ago > MAX_CACHE_AGE => {
                 if args.flag_auto_update {
-                    cache.update().unwrap_or_else(|e| {
-                        match e {
-                            CacheError(msg) | ConfigError(msg) | UpdateError(msg) => {
-                                eprintln!("Could not update cache: {}", msg)
+                    cache.update()
+                        .map(|()| {
+                            if !args.flag_quiet {
+                                println!("Successfully updated cache.");
                             }
-                        };
-                    });
+                        })
+                        .unwrap_or_else(|e| {
+                            match e {
+                                CacheError(msg) | ConfigError(msg) | UpdateError(msg) => {
+                                    eprintln!("Could not update cache: {}", msg)
+                                }
+                            };
+                        });
                     return;
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,18 +127,14 @@ fn check_cache(args: &Args, cache: &Cache) {
             Some(ago) if ago > MAX_CACHE_AGE => {
                 if args.flag_auto_update {
                     match cache.update() {
-                        Ok(()) => {
-                            if !args.flag_quiet {
-                                println!("Successfully updated cache.");
+                        Ok(()) => if !args.flag_quiet {
+                            println!("Successfully updated cache.");
+                        },
+                        Err(err) => match err {
+                            CacheError(msg) | ConfigError(msg) | UpdateError(msg) => {
+                                eprintln!("Could not update cache: {}", msg)
                             }
-                        }
-                        Err(err) => {
-                            match err {
-                                CacheError(msg) | ConfigError(msg) | UpdateError(msg) => {
-                                    eprintln!("Could not update cache: {}", msg)
-                                }
-                            };
-                        }
+                        },
                     }
                     return;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,19 +126,20 @@ fn check_cache(args: &Args, cache: &Cache) {
         match cache.last_update() {
             Some(ago) if ago > MAX_CACHE_AGE => {
                 if args.flag_auto_update {
-                    cache.update()
-                        .map(|()| {
+                    match cache.update() {
+                        Ok(()) => {
                             if !args.flag_quiet {
                                 println!("Successfully updated cache.");
                             }
-                        })
-                        .unwrap_or_else(|e| {
-                            match e {
+                        }
+                        Err(err) => {
+                            match err {
                                 CacheError(msg) | ConfigError(msg) | UpdateError(msg) => {
                                     eprintln!("Could not update cache: {}", msg)
                                 }
                             };
-                        });
+                        }
+                    }
                     return;
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ Options:
     -f --render <file>  Render a specific markdown file
     -o --os <type>      Override the operating system [linux, osx, sunos]
     -u --update         Update the local cache
-    -a --auto-update    Update the local cache automatically if out of date
+    -a --auto-update    Update the local cache automatically if older than 30 days
     -c --clear-cache    Clear the local cache
     -q --quiet          Suppress informational messages
     --config-path       Show config file path


### PR DESCRIPTION
When not updating the cache manually one often gets the following
message:

    Cache wasn't updated in 30 days.
    You should probably run `tldr --update` soon.

The auto-update flag allows to just alias tldr to tldr -a which will
automatically update the cache if it is older than the maximum age.