### PR TITLE
Use `string replace` instead of `sed`

### DIFF
--- a/fish_tealdeer
+++ b/fish_tealdeer
@@ -15,7 +15,7 @@ complete -c tldr      -l config-path -d 'Show config file path.' -f
 complete -c tldr      -l seed-config -d 'Create a basic config.' -f
 
 function __tealdeer_entries
-    tldr --list | sed -e 's/, /\n/g'
+    tldr --list | string replace -a -i -r "\,\s" "\n"
 end
 
 complete -f -c tldr -a '(__tealdeer_entries)'


### PR DESCRIPTION
It seems like this was broken on my machine (OSX, 10.14.6) when using the completions. It would strip the `, ` but it would not add a proper newline. Instead it added nothing. So it just become a giant single line. Basically, it didn’t work.

With this change, the string gets split properly. Since this is fish shell, the `string replace` command is guaranteed to be there.