### PR TITLE
Add compact output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,14 +180,25 @@ Example customization:
 
 ### Display
 
-Using `display` config you can customize whether the pager should be use by
-default or not (default `false`).
+In the `display` section you can configure the output format.
+
+#### `use_pager`
+
+Specifies whether the pager should be used by default or not (default `false`).
 
     [display]
     use_pager = true
 
 When enabled, `less -R` is used as pager. To override the pager command used,
 set the `PAGER` environment variable.
+
+#### `compact`
+
+Set this to enforce more compact output, where empty lines are stripped out
+(default `false`).
+
+    [display]
+    compact = true
 
 
 ## Autocompletion

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,8 @@ struct RawStyleConfig {
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct RawDisplayConfig {
     #[serde(default)]
+    pub compact: bool,
+    #[serde(default)]
     pub use_pager: bool,
 }
 
@@ -149,6 +151,7 @@ pub struct StyleConfig {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct DisplayConfig {
+    pub compact: bool,
     pub use_pager: bool,
 }
 
@@ -169,6 +172,7 @@ impl From<RawConfig> for Config {
                 example_variable: raw_config.style.example_variable.into(),
             },
             display: DisplayConfig {
+                compact: raw_config.display.compact,
                 use_pager: raw_config.display.use_pager,
             },
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -57,7 +57,11 @@ where
     let mut command = String::new();
     while let Some(token) = tokenizer.next_token() {
         match token {
-            LineType::Empty => println!(),
+            LineType::Empty => {
+                if !config.display.compact {
+                    println!()
+                }
+            }
             LineType::Title(title) => {
                 debug!("Ignoring title");
 

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -18,3 +18,4 @@ bold = false
 
 [display]
 use_pager = false
+compact = false


### PR DESCRIPTION
This adds a config option to suppress empty lines in the output.

Closes #88.