### PR TITLE
Add -m / --markdown option for raw rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These are the clients I tried but failed to compile or run:
         -u --update          Update the local cache
         -c --clear-cache     Clear the local cache
         -p --pager           Use a pager to page output
+        -m --markdown        Display the raw markdown instead of rendering it
         -q --quiet           Suppress informational messages
         --config-path        Show config file path
         --seed-config        Create a basic config

--- a/bash_tealdeer
+++ b/bash_tealdeer
@@ -6,7 +6,7 @@ _tealdeer()
 	_init_completion || return
 
 	case $prev in
-		-h|--help|-v|--version|-l|--list|-u|--update|-c|--clear-cache|--config-path|--seed-config|-q|--quiet)
+		-h|--help|-v|--version|-l|--list|-u|--update|-c|--clear-cache|-p|--pager|-m|--markdown|--config-path|--seed-config|-q|--quiet)
 			return
 			;;
 		-f|--render)

--- a/fish_tealdeer
+++ b/fish_tealdeer
@@ -10,6 +10,8 @@ complete -c tldr -s f -l render      -d 'Render a specific markdown file.' -r
 complete -c tldr -s o -l os          -d 'Override the operating system.' -xa 'linux osx sunos windows other'
 complete -c tldr -s u -l update      -d 'Update the local cache.' -f
 complete -c tldr -s c -l clear-cache -d 'Clear the local cache.' -f
+complete -c tldr -s p -l pager       -d 'Use a pager to page output.' -f
+complete -c tldr -s m -l markdown    -d 'Display the raw markdown instead of rendering it.' -f
 complete -c tldr -s q -l quiet       -d 'Suppress informational messages.' -f
 complete -c tldr      -l config-path -d 'Show config file path.' -f
 complete -c tldr      -l seed-config -d 'Create a basic config.' -f

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -193,6 +193,26 @@ fn test_show_config_path() {
         )));
 }
 
+#[test]
+fn test_markdown_rendering() {
+    let testenv = TestEnv::new();
+
+    testenv
+        .command()
+        .args(&["--update"])
+        .assert()
+        .success()
+        .stdout(contains("Successfully updated cache."));
+
+    let expected = include_str!("tar-markdown.expected");
+    testenv
+        .command()
+        .args(&["-m", "tar"])
+        .assert()
+        .success()
+        .stdout(similar(expected));
+}
+
 fn _test_correct_rendering(input_file: &str, filename: &str) {
     let testenv = TestEnv::new();
 
@@ -202,9 +222,7 @@ fn _test_correct_rendering(input_file: &str, filename: &str) {
     let mut file = File::create(&file_path).unwrap();
     file.write_all(input_file.as_bytes()).unwrap();
 
-    // Load expected output
     let expected = include_str!("inkscape-default.expected");
-
     testenv
         .command()
         .args(&["-f", &file_path.to_str().unwrap()])

--- a/tests/tar-markdown.expected
+++ b/tests/tar-markdown.expected
@@ -1,0 +1,33 @@
+# tar
+
+> Archiving utility.
+> Often combined with a compression method, such as gzip or bzip.
+> More information: <https://www.gnu.org/software/tar>.
+
+- Create an archive from files:
+
+`tar cf {{target.tar}} {{file1}} {{file2}} {{file3}}`
+
+- Create a gzipped archive:
+
+`tar czf {{target.tar.gz}} {{file1}} {{file2}} {{file3}}`
+
+- Extract a (compressed) archive into the current directory:
+
+`tar xf {{source.tar[.gz|.bz2|.xz]}}`
+
+- Extract an archive into a target directory:
+
+`tar xf {{source.tar}} -C {{directory}}`
+
+- Create a compressed archive, using archive suffix to determine the compression program:
+
+`tar caf {{target.tar.xz}} {{file1}} {{file2}} {{file3}}`
+
+- List the contents of a tar file:
+
+`tar tvf {{source.tar}}`
+
+- Extract files matching a pattern:
+
+`tar xf {{source.tar}} --wildcards {{"*.html"}}`

--- a/zsh_tealdeer
+++ b/zsh_tealdeer
@@ -8,7 +8,7 @@ _tealdeer() {
     local I="-h --help -v --version"
     integer ret=1
     local -a args
-    
+
     args+=(
         "($I -l --list)"{-l,--list}"[List all commands in the cache]"
 	"($I -f --render)"{-f,--render}"[Render a specific markdown file]:file:_files"
@@ -21,6 +21,7 @@ _tealdeer() {
 	"($I -u --update)"{-u,--update}"[Update the local cache]"
 	"($I -c --clear-cache)"{-c,--clear-cache}"[Clear the local cache]"
 	"($I -p --pager)"{-p,--pager}"[Use a pager to page output]"
+	"($I -m --markdown)"{-m,--markdown}"[Display the raw markdown instead of rendering it]"
 	"($I -q --quiet)"{-q,--quiet}"[Suppress informational messages]"
 	"($I)--config-path[Show config file path]"
 	"($I)--seed-config[Create a basic config]"
@@ -29,7 +30,7 @@ _tealdeer() {
     	'*:file:_files'
 	'1: :_applications'
     )
-    
+
     _arguments $args[@] && ret=0
     return ret
 }


### PR DESCRIPTION
This is useful for when you want to open it up in a pager which doesn't
support ansi escape codes by default. In my use case it allows me to
open it inside vim without having to use an addon to convert ansi escape
codes to colours.