### PR TITLE
Tweak the outdated cache warning message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,8 +164,8 @@ fn check_cache(args: &Args, cache: &Cache) {
                 }
                 println!(
                     "{}",
-                    Color::Red.paint(format!(
-                        "Cache wasn't updated for more than {} days.\n\
+                    Color::Yellow.paint(format!(
+                        "The cache hasn't been updated for more than {} days.\n\
                          You should probably run `tldr --update` soon.",
                         MAX_CACHE_AGE.as_secs() / 24 / 3600
                     ))

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -156,14 +156,14 @@ fn test_quiet_old_cache() {
         .args(&["tldr"])
         .assert()
         .success()
-        .stdout(contains("Cache wasn't updated for more than "));
+        .stdout(contains("The cache hasn't been updated for more than "));
 
     testenv
         .command()
         .args(&["tldr", "--quiet"])
         .assert()
         .success()
-        .stdout(contains("Cache wasn't updated for more than ").not());
+        .stdout(contains("The cache hasn't been updated for more than ").not());
 }
 
 #[test]


### PR DESCRIPTION
This makes it display in yellow (instead of red) as it's more of a *warning* message than an *error* message.