### PR TITLE
Windows: Only warn about missing pager if flag set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,8 +168,10 @@ fn configure_pager(args: &Args, enable_styles: bool) {
 }
 
 #[cfg(target_os = "windows")]
-fn configure_pager(_args: &Args, _enable_styles: bool) {
-    eprintln!("Warning: -p / --pager flag not available on Windows!");
+fn configure_pager(args: &Args, _enable_styles: bool) {
+    if args.flag_pager {
+        eprintln!("Warning: -p / --pager flag not available on Windows!");
+    }
 }
 
 /// Check the cache for freshness


### PR DESCRIPTION
Hi, thanks for writing tealdeer! It's by far my favourite tldr client.

### PR

I recently installed tealdeer on my Windows machine, and I noticed that the following message is printed on _every_ invocation:

> Warning: -p / --pager flag not available on Windows!

This is a bit annoying to see every time, so I implemented a change to only show the message if the -p/--pager flag is true.

### Testing performed

All tests performed on Windows 10 (1909). Ran `cargo test` successfully before+after the change. Ran `tldr`, `tldr ls`, `tldr -p ls`, and `tldr --pager ls` and confirmed expected output.