### PR TITLE
Better color detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs2 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 ansi_term = "0.12.0"
 app_dirs = { version = "2", package = "app_dirs2" }
+atty = "0.2"
 docopt = "1"
 env_logger = { version = "0.7", optional = true }
 flate2 = "1"

--- a/bash_tealdeer
+++ b/bash_tealdeer
@@ -17,6 +17,10 @@ _tealdeer()
 			COMPREPLY=( $(compgen -W 'linux osx sunos windows' -- "${cur}") )
 			return
 			;;
+		--color)
+			COMPREPLY=( $(compgen -W 'always auto never' -- "${cur}") )
+			return
+			;;
 	esac
 
 	if [[ $cur == -* ]]; then

--- a/fish_tealdeer
+++ b/fish_tealdeer
@@ -15,6 +15,7 @@ complete -c tldr -s m -l markdown    -d 'Display the raw markdown instead of ren
 complete -c tldr -s q -l quiet       -d 'Suppress informational messages.' -f
 complete -c tldr      -l config-path -d 'Show config file path.' -f
 complete -c tldr      -l seed-config -d 'Create a basic config.' -f
+complete -c tldr      -l color       -d 'Controls when to use color.' -xa 'always auto never'
 
 function __tealdeer_entries
     tldr --list | string replace -a -i -r "\,\s" "\n"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
 #[cfg(feature = "logging")]
 extern crate env_logger;
 
+use std::env;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -296,8 +297,6 @@ fn main() {
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
 
-    println!("{:?}", args);
-
     // Show version and exit
     if args.flag_version {
         let os = get_os();
@@ -322,8 +321,12 @@ fn main() {
     let ansi_support = true;
 
     let enable_styles = match args.flag_color {
+        // Always use styling as long as there is `ansi_support`
         ColorOptions::Always => ansi_support,
-        ColorOptions::Auto => ansi_support,
+        // Disable if:
+        // * NO_COLOR env var is set to anything: https://no-color.org/
+        ColorOptions::Auto => ansi_support && env::var_os("NO_COLOR").is_none(),
+        // Disable styling
         ColorOptions::Never => false,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::process;
 
 use ansi_term::{Color, Style};
 use app_dirs::AppInfo;
+use atty::Stream;
 use docopt::Docopt;
 #[cfg(not(target_os = "windows"))]
 use pager::Pager;
@@ -323,9 +324,13 @@ fn main() {
     let enable_styles = match args.flag_color {
         // Always use styling as long as there is `ansi_support`
         ColorOptions::Always => ansi_support,
-        // Disable if:
-        // * NO_COLOR env var is set to anything: https://no-color.org/
-        ColorOptions::Auto => ansi_support && env::var_os("NO_COLOR").is_none(),
+        // Enable styling if:
+        // * There is `ansi_support`
+        // * NO_COLOR env var isn't set: https://no-color.org/
+        // * The output stream is stdout (not being piped)
+        ColorOptions::Auto => {
+            ansi_support && env::var_os("NO_COLOR").is_none() && atty::is(Stream::Stdout)
+        }
         // Disable styling
         ColorOptions::Never => false,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,8 +322,8 @@ fn main() {
     let ansi_support = true;
 
     let enable_styles = match args.flag_color {
-        // Always use styling as long as there is `ansi_support`
-        ColorOptions::Always => ansi_support,
+        // Attempt to use styling if instructed
+        ColorOptions::Always => true,
         // Enable styling if:
         // * There is `ansi_support`
         // * NO_COLOR env var isn't set: https://no-color.org/

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,14 @@ impl fmt::Display for OsType {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ColorOptions {
+    Always,
+    Auto,
+    Never,
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum LineType {
     Empty,

--- a/tests/inkscape-default-no-color.expected
+++ b/tests/inkscape-default-no-color.expected
@@ -1,0 +1,28 @@
+
+  An SVG (Scalable Vector Graphics) editing program.
+  Use -z to not open the GUI and only process files in the console.
+
+  Open an SVG file in the Inkscape GUI:
+
+      inkscape filename.svg
+
+  Export an SVG file into a bitmap with the default format (PNG) and the default resolution (90 DPI):
+
+      inkscape filename.svg -e filename.png
+
+  Export an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):
+
+      inkscape filename.svg -e filename.png -w 600 -h 400
+
+  Export a single object, given its ID, into a bitmap:
+
+      inkscape filename.svg -i id -e object.png
+
+  Export an SVG document to PDF, converting all texts to paths:
+
+      inkscape filename.svg | inkscape | inkscape --export-pdf=inkscape.pdf | inkscape | inkscape --export-text-to-path
+
+  Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
+
+      inkscape filename.svg --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
+

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -253,7 +253,7 @@ fn _test_correct_rendering(input_file: &str, filename: &str) {
     let expected = include_str!("inkscape-default.expected");
     testenv
         .command()
-        .args(&["-f", &file_path.to_str().unwrap()])
+        .args(&["--color", "always", "-f", &file_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(similar(expected));
@@ -299,7 +299,7 @@ fn test_correct_rendering_with_config() {
 
     testenv
         .command()
-        .args(&["-f", &file_path.to_str().unwrap()])
+        .args(&["--color", "always", "-f", &file_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(similar(expected));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -241,7 +241,12 @@ fn test_markdown_rendering() {
         .stdout(similar(expected));
 }
 
-fn _test_correct_rendering(input_file: &str, filename: &str) {
+fn _test_correct_rendering(
+    input_file: &str,
+    filename: &str,
+    expected: &'static str,
+    color_option: &str,
+) {
     let testenv = TestEnv::new();
 
     // Create input file
@@ -250,10 +255,9 @@ fn _test_correct_rendering(input_file: &str, filename: &str) {
     let mut file = File::create(&file_path).unwrap();
     file.write_all(input_file.as_bytes()).unwrap();
 
-    let expected = include_str!("inkscape-default.expected");
     testenv
         .command()
-        .args(&["--color", "always", "-f", &file_path.to_str().unwrap()])
+        .args(&["--color", color_option, "-f", &file_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(similar(expected));
@@ -262,13 +266,46 @@ fn _test_correct_rendering(input_file: &str, filename: &str) {
 /// An end-to-end integration test for direct file rendering (v1 syntax).
 #[test]
 fn test_correct_rendering_v1() {
-    _test_correct_rendering(include_str!("inkscape-v1.md"), "inkscape-v1.md");
+    _test_correct_rendering(
+        include_str!("inkscape-v1.md"),
+        "inkscape-v1.md",
+        include_str!("inkscape-default.expected"),
+        "always",
+    );
 }
 
 /// An end-to-end integration test for direct file rendering (v2 syntax).
 #[test]
 fn test_correct_rendering_v2() {
-    _test_correct_rendering(include_str!("inkscape-v2.md"), "inkscape-v2.md");
+    _test_correct_rendering(
+        include_str!("inkscape-v2.md"),
+        "inkscape-v2.md",
+        include_str!("inkscape-default.expected"),
+        "always",
+    );
+}
+
+#[test]
+/// An end-to-end integration test for direct file rendering with the `--color auto` option. This
+/// will not use styling since output is not stdout.
+fn test_rendering_color_auto() {
+    _test_correct_rendering(
+        include_str!("inkscape-v2.md"),
+        "inkscape-v2.md",
+        include_str!("inkscape-default-no-color.expected"),
+        "auto",
+    );
+}
+
+#[test]
+/// An end-to-end integration test for direct file rendering with the `--color never` option.
+fn test_rendering_color_never() {
+    _test_correct_rendering(
+        include_str!("inkscape-v2.md"),
+        "inkscape-v2.md",
+        include_str!("inkscape-default-no-color.expected"),
+        "never",
+    );
 }
 
 /// An end-to-end integration test for rendering with constom syntax config.

--- a/zsh_tealdeer
+++ b/zsh_tealdeer
@@ -25,6 +25,11 @@ _tealdeer() {
 	"($I -q --quiet)"{-q,--quiet}"[Suppress informational messages]"
 	"($I)--config-path[Show config file path]"
 	"($I)--seed-config[Create a basic config]"
+	"($I --color)"{--color}'[Controls when to use color]:when:((
+	    always
+	    auto
+	    never
+        ))'
 	'(- *)'{-h,--help}'[Display help]'
     	'(- *)'{-v,--version}'[Show version information]'
     	'*:file:_files'


### PR DESCRIPTION
Hello, first time hacking at this codebase.

So the aim of this pull request is to address the issues mentioned in #81. This was done by adding in a command line flag `--color` with the options `always, auto, never`.

## `--color <WHEN>`

### `--color always` (The previous behavior of `tealdeer`)

Will use styling as long as ANSI support is detected.

### `--color auto`

Will use color _unless_:
* ANSI support isn't detected.
* The `NO_COLOR` environment variable exists as is the spec listed on the [`NO_COLOR` website](https://no-color.org/).
* The output isn't `stdout` (e.g. when the output is being piped to another program like `tldr man | xclip -sel clip`). This is done with the help of the newly added `atty` lib since it promises cross platform detection for such cases.

### `--color never`

Disables colored output entirely.

## Misc

* There was the case where the stale cache message attempted to be colored regardless of ANSI support, so I did need to tweak `check_cache` to make style checking consistent.
* I fixed any of the tests that seemed to be failing because of these changes: however, `test_markdown_rendering` seems to be failing because of changes to the `tar` page compared to `tar-markdown.expected` that I left failing as it's outside the scope of this PR.
* These changes were all tested exclusively on Linux since I don't have a rust dev environment setup for Windows and I don't have access to any other systems. 