### PR TITLE
Make list option display comply with official spec

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -385,7 +385,7 @@ fn main() {
         });
 
         // Print pages
-        println!("{}", pages.join(", "));
+        println!("{}", pages.join("\n"));
         process::exit(0);
     }
 


### PR DESCRIPTION
**TL;DR** make commands list display write one item per line instead of comma-separated items.

Tealdeer currently displays command list comma-separated, _e.g._
```sh
$ tldr --list
bar, baz, foo, qux
```
Whereas the [official TLDR specification](https://github.com/tldr-pages/tldr/blob/master/CLIENT-SPECIFICATION.md#arguments) states the following
> Additional decoration MAY be printed if the standard output is a TTY. If not, then the output MUST not contain any additional decorations. For example a page list MUST be formatted with 1 page name per line (to enable easy manipulation using standard CLI tools such as grep etc.).

_e.g._
```sh
$ tldr --list
bar
baz
foo
qux
```
Adding TTY-specific decorated output goes against [KISS principle](https://www.google.com/search?q=kiss+principle&oq=kiss+principle&aqs=chrome..69i57j46j0l4j69i60l2.2341j0j2&sourceid=chrome&ie=UTF-8) in my opinion. On top of that, even considering adding metadata to items display (like some kind of version or tags or anything) still makes non-line-wise display pretty undesirable for every use case I can think about.