### PR TITLE
Implement automatic cache updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -996,7 +996,7 @@ name = "tar"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,6 +1012,7 @@ dependencies = [
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pager 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1022,7 +1023,6 @@ dependencies = [
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1178,16 +1178,6 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "utime"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1420,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
-"checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+"checksum filetime 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum float-cmp 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da62c4f1b81918835a8c6a484a397775fff5953fe83529afd51b05f5c6a6617d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1533,7 +1523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
-"checksum utime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "055058552ca15c566082fc61da433ae678f78986a6f16957e33162d1b218792a"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ assert_cmd = "0.10"
 escargot = "0.3"
 predicates = "1.0"
 tempdir = "^0.3"
-utime = "0.2.0"
+filetime = "0.2.10"
 
 [features]
 logging = ["env_logger"]

--- a/README.md
+++ b/README.md
@@ -208,6 +208,31 @@ Set this to enforce more compact output, where empty lines are stripped out
     compact = true
 
 
+### Automatic updates
+
+tealdeer can refresh the cache automatically when it is outdated. This
+behavior can be configured in the `updates` section and is disabled by
+default.
+
+#### `auto_update`
+
+Specifies whether the auto-update feature should be enabled (defaults to
+`false`).
+
+    [updates]
+    auto_update = true
+
+#### `auto_update_interval_hours`
+
+Duration, since the last cache update, after which the cache will be
+refreshed (defaults to 720 hours). This parameter is ignored if `auto_update`
+is set to `false`.
+
+    [updates]
+    auto_update = true
+    auto_update_interval_hours = 24
+
+
 ## Autocompletion
 
 - *Bash*: copy `bash_tealdeer` to `/usr/share/bash-completion/completions/tldr`

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -19,3 +19,7 @@ bold = false
 [display]
 use_pager = false
 compact = false
+
+[updates]
+auto_update = false
+auto_update_interval_hours = 720

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -354,3 +354,61 @@ fn test_list_flag_rendering() {
         .success()
         .stdout("bar\nbaz\nfoo\nqux\n");
 }
+
+#[test]
+fn test_autoupdate_cache() {
+    let testenv = TestEnv::new();
+
+    // The first time, if automatic updates are disabled, the cache should not be found
+    testenv
+        .command()
+        .args(&["--list"])
+        .assert()
+        .failure()
+        .stderr(contains("Cache not found. Please run `tldr --update`."));
+
+    let config_file_path = testenv.config_dir.path().join("config.toml");
+    let cache_file_path = testenv.cache_dir.path().join("tldr-master");
+
+    // Activate automatic updates, set the auto-update interval to 24 hours
+    let mut config_file = File::create(&config_file_path).unwrap();
+    config_file
+        .write("[updates]\nauto_update = true\nauto_update_interval_hours = 24".as_bytes())
+        .unwrap();
+    config_file.flush().unwrap();
+
+    // Helper function that runs `tldr --list` and asserts that the cache is automatically updated
+    // or not, depending on the value of `expected`.
+    let check_cache_updated = |expected| {
+        let assert = testenv.command().args(&["--list"]).assert().success();
+        let pred = contains("Successfully updated cache");
+        if expected {
+            assert.stdout(pred)
+        } else {
+            assert.stdout(pred.not())
+        };
+    };
+
+    // The cache is updated the first time we run `tldr --list`
+    check_cache_updated(true);
+
+    // The cache is not updated with a subsequent call
+    check_cache_updated(false);
+
+    let (_, orig_mtime) = utime::get_file_times(&cache_file_path).unwrap();
+
+    // We update the modification and access times such that they are about 23 hours from now.
+    // auto-update interval is 24 hours, the cache should not be updated
+    let new_mtime = orig_mtime - 82_800;
+    utime::set_file_times(&cache_file_path, new_mtime, new_mtime).unwrap();
+    check_cache_updated(false);
+
+    // We update the modification and access times such that they are about 25 hours from now.
+    // auto-update interval is 24 hours, the cache should be updated
+    let new_mtime = orig_mtime - 90_000;
+    utime::set_file_times(&cache_file_path, new_mtime, new_mtime).unwrap();
+    check_cache_updated(true);
+
+    // The cache is not updated with a subsequent call
+    check_cache_updated(false);
+}


### PR DESCRIPTION
This PR implements automatic updates of the cache.

This behavior is disabled by default and can be enabled in `config.toml`:

```toml
[updates]
auto_update = true
auto_update_interval_hours = 720
```

Fixes #90
Fixes #78