### PR TITLE
Tests: Allow dead code for feature selection

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -44,12 +44,14 @@ impl TestEnv {
     }
 
     /// Disable default features.
+    #[allow(dead_code)] // Might be useful in the future
     fn no_default_features(mut self) -> Self {
         self.default_features = false;
         self
     }
 
     /// Add the specified feature.
+    #[allow(dead_code)] // Might be useful in the future
     fn with_feature<S: Into<String>>(mut self, feature: S) -> Self {
         self.features.push(feature.into());
         self


### PR DESCRIPTION
These methods might be useful in the future, so I don't want to remove them even if they're unused. The warnings clutter diffs in CI though.