### PR TITLE
Add support for ANSI code and RGB colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,12 @@ Possible styles:
 
 Currently supported attributes:
 
-- `foreground` (color string, see below)
-- `background` (color string, see below)
+- `foreground` (color string, ANSI code, or RGB, see below)
+- `background` (color string, ANSI code, or RGB, see below)
 - `underline` (`true` or `false`)
 - `bold` (`true` or `false`)
 
-The currently supported colors are:
+The currently supported color strings are:
 
 - `black`
 - `red`
@@ -189,6 +189,16 @@ The currently supported colors are:
 - `purple`
 - `cyan`
 - `white`
+
+ANSI color codes are also supported:
+```
+foreground = { ansi = 4 }
+```
+
+Finally, colors can also be configured by their RGB representation:
+```
+background = { rgb = { r = 255, g = 255, b = 255 } }
+```
 
 Example customization:
 

--- a/README.md
+++ b/README.md
@@ -191,14 +191,12 @@ The currently supported color strings are:
 - `white`
 
 ANSI color codes are also supported:
-```
-foreground = { ansi = 4 }
-```
+
+    foreground = { ansi = 4 }
 
 Finally, colors can also be configured by their RGB representation:
-```
-background = { rgb = { r = 255, g = 255, b = 255 } }
-```
+
+    background = { rgb = { r = 255, g = 255, b = 255 } }
 
 Example customization:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,7 @@ pub enum RawColor {
     Purple,
     Cyan,
     White,
-    ANSI(u8),
+    Ansi(u8),
     RGB { r: u8, g: u8, b: u8 },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ pub enum RawColor {
     Cyan,
     White,
     ANSI(u8),
-    RGB{r: u8, g: u8, b: u8},
+    RGB { r: u8, g: u8, b: u8 },
 }
 
 impl From<RawColor> for Color {
@@ -50,7 +50,7 @@ impl From<RawColor> for Color {
             RawColor::Cyan => Self::Cyan,
             RawColor::White => Self::White,
             RawColor::ANSI(num) => Self::Fixed(num),
-            RawColor::RGB {r, g, b} => Self::RGB(r, g, b),
+            RawColor::RGB { r, g, b } => Self::RGB(r, g, b),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl From<RawColor> for Color {
             RawColor::Purple => Self::Purple,
             RawColor::Cyan => Self::Cyan,
             RawColor::White => Self::White,
-            RawColor::ANSI(num) => Self::Fixed(num),
+            RawColor::Ansi(num) => Self::Fixed(num),
             RawColor::RGB { r, g, b } => Self::RGB(r, g, b),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,8 @@ pub enum RawColor {
     Purple,
     Cyan,
     White,
+    ANSI(u8),
+    RGB{r: u8, g: u8, b: u8},
 }
 
 impl From<RawColor> for Color {
@@ -47,6 +49,8 @@ impl From<RawColor> for Color {
             RawColor::Purple => Self::Purple,
             RawColor::Cyan => Self::Cyan,
             RawColor::White => Self::White,
+            RawColor::ANSI(num) => Self::Fixed(num),
+            RawColor::RGB {r, g, b} => Self::RGB(r, g, b),
         }
     }
 }


### PR DESCRIPTION
Closes #147

Allows defining colors as ANSI codes or RGB in `config.toml` e.g.:

```
[style.command_name]
background = { ansi = 7 }
foreground =  { rgb = { r = 255, g = 51, b = 255 } }
```