### PR TITLE
Consider only standalone command names for styling

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -19,7 +19,20 @@ fn highlight_command<'a>(
     while let Some(command_start) = example_code[code_part_end_pos..].find(&command) {
         let code_part = &example_code[code_part_end_pos..code_part_end_pos + command_start];
         parts.push(config.style.example_code.paint(code_part));
-        parts.push(config.style.command_name.paint(command));
+        if code_part_end_pos == 0 {
+            // Only highlight command names at the start of the line ...
+            parts.push(config.style.command_name.paint(command));
+        } else {
+            let char_before_command = example_code
+                .chars()
+                .nth(code_part_end_pos + command_start - 1);
+            if char_before_command.filter(|c| c.is_whitespace()).is_some() {
+                // ... or when preceded by a whitespace character.
+                parts.push(config.style.command_name.paint(command));
+            } else {
+                parts.push(config.style.example_code.paint(command));
+            }
+        }
 
         code_part_end_pos += command_start + command.len();
     }

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -3,6 +3,9 @@ foreground = "green"
 underline = false
 bold = false
 
+[style.command_name]
+bold = true
+
 [style.description]
 underline = false
 bold = false

--- a/tests/inkscape-default-no-color.expected
+++ b/tests/inkscape-default-no-color.expected
@@ -26,3 +26,7 @@
 
       inkscape filename.svg --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
 
+  Some invalid command just to test the correct highlighting of the command name:
+
+      inkscape --use-inkscape=v3.0 file
+

--- a/tests/inkscape-default.expected
+++ b/tests/inkscape-default.expected
@@ -26,3 +26,7 @@
 
       [36minkscape [4mfilename.svg[0m[36m --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit[0m
 
+  [32mSome invalid command just to test the correct highlighting of the command name:[0m
+
+      [36minkscape --use-inkscape=v3.0 file[0m
+

--- a/tests/inkscape-v1.md
+++ b/tests/inkscape-v1.md
@@ -26,3 +26,7 @@
 - Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
 
 `inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit`
+
+- Some invalid command just to test the correct highlighting of the command name:
+
+`inkscape --use-inkscape=v3.0 file`

--- a/tests/inkscape-v2.md
+++ b/tests/inkscape-v2.md
@@ -27,3 +27,7 @@ Export an SVG document to PDF, converting all texts to paths:
 Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
 
     inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
+
+Some invalid command just to test the correct highlighting of the command name:
+
+    inkscape --use-inkscape=v3.0 file

--- a/tests/inkscape-with-config.expected
+++ b/tests/inkscape-with-config.expected
@@ -4,25 +4,29 @@
 
   [44;30mOpen an SVG file in the Inkscape GUI:[0m
 
-      inkscape [4mfilename.svg[0m
+      [1minkscape[0m [4mfilename.svg[0m
 
   [44;30mExport an SVG file into a bitmap with the default format (PNG) and the default resolution (90 DPI):[0m
 
-      inkscape [4mfilename.svg[0m -e [4mfilename.png[0m
+      [1minkscape[0m [4mfilename.svg[0m -e [4mfilename.png[0m
 
   [44;30mExport an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):[0m
 
-      inkscape [4mfilename.svg[0m -e [4mfilename.png[0m -w [4m600[0m -h [4m400[0m
+      [1minkscape[0m [4mfilename.svg[0m -e [4mfilename.png[0m -w [4m600[0m -h [4m400[0m
 
   [44;30mExport a single object, given its ID, into a bitmap:[0m
 
-      inkscape [4mfilename.svg[0m -i [4mid[0m -e [4mobject.png[0m
+      [1minkscape[0m [4mfilename.svg[0m -i [4mid[0m -e [4mobject.png[0m
 
   [44;30mExport an SVG document to PDF, converting all texts to paths:[0m
 
-      inkscape [4mfilename.svg[0m | inkscape | inkscape --export-pdf=[4minkscape.pdf[0m | inkscape | inkscape --export-text-to-path
+      [1minkscape[0m [4mfilename.svg[0m | [1minkscape[0m | [1minkscape[0m --export-pdf=[4minkscape.pdf[0m | [1minkscape[0m | [1minkscape[0m --export-text-to-path
 
   [44;30mDuplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:[0m
 
-      inkscape [4mfilename.svg[0m --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
+      [1minkscape[0m [4mfilename.svg[0m --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
+
+  [44;30mSome invalid command just to test the correct highlighting of the command name:[0m
+
+      [1minkscape[0m --use-inkscape=v3.0 file
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -308,7 +308,7 @@ fn test_rendering_color_never() {
     );
 }
 
-/// An end-to-end integration test for rendering with constom syntax config.
+/// An end-to-end integration test for rendering with custom syntax config.
 #[test]
 fn test_correct_rendering_with_config() {
     let testenv = TestEnv::new();


### PR DESCRIPTION
In my styling configuration, command names are printed boldly. With that, one part of the TL;DR page for the command `make` looks like:

![make-before](https://user-images.githubusercontent.com/16365760/102695917-bf459480-422a-11eb-94a9-67507a12fb89.png)

You clearly see the "make" in the command line argument `--always-make` printed boldly too. I guess this shouldn't be the case. This fix makes sure that only command names with a preceding whitespace character are considered, which leads to:

![make-after](https://user-images.githubusercontent.com/16365760/102695997-662a3080-422b-11eb-91d7-bc8b7c776026.png)
