### PR TITLE
tar markdown rendering test fixed

### DIFF
--- a/tests/tar-markdown.expected
+++ b/tests/tar-markdown.expected
@@ -4,38 +4,34 @@
 > Often combined with a compression method, such as gzip or bzip.
 > More information: <https://www.gnu.org/software/tar>.
 
-- Create an archive from files:
+- [c]reate an archive from [f]iles:
 
 `tar cf {{target.tar}} {{file1}} {{file2}} {{file3}}`
 
-- Create a gzipped archive:
+- [c]reate a g[z]ipped archive from [f]iles:
 
 `tar czf {{target.tar.gz}} {{file1}} {{file2}} {{file3}}`
 
-- Create a gzipped archive from a directory using relative paths:
+- [c]reate a g[z]ipped archive from a directory using relative paths:
 
-`tar czf {{target.tar.gz}} -C {{path/to/directory}} .`
+`tar czf {{target.tar.gz}} --directory={{path/to/directory}} .`
 
-- Extract a (compressed) archive into the current directory:
+- E[x]tract a (compressed) archive [f]ile into the current directory:
 
 `tar xf {{source.tar[.gz|.bz2|.xz]}}`
 
-- Extract a (compressed) archive into the target directory:
+- E[x]tract a (compressed) archive [f]ile into the target directory:
 
-`tar xf {{source.tar[.gz|.bz2|.xz]}} -C {{directory}}`
+`tar xf {{source.tar[.gz|.bz2|.xz]}} --directory={{directory}}`
 
-- Create a compressed archive, using archive suffix to determine the compression program:
+- [c]reate a compressed archive from [f]iles, using [a]rchive suffix to determine the compression program:
 
 `tar caf {{target.tar.xz}} {{file1}} {{file2}} {{file3}}`
 
-- List the contents of a tar file:
+- Lis[t] the contents of a tar [f]ile [v]erbosely:
 
 `tar tvf {{source.tar}}`
 
-- Extract files matching a pattern:
+- E[x]tract [f]iles matching a pattern:
 
 `tar xf {{source.tar}} --wildcards "{{*.html}}"`
-
-- Extract a specific file without preserving the folder structure:
-
-`tar xf {{source.tar}} {{source.tar/path/to/extract}} --strip-components={{depth_to_strip}}`


### PR DESCRIPTION
Build tests failing because tldr-pages repository changed file
https://github.com/tldr-pages/tldr/blob/master/pages/common/tar.md
and so test was failing, as the file the test compared to was not the version pulled from the archive.
Could attempt to generate this automatically in future?

Not very familiar with pull requests, so please let me know what would be helpful in future.