### PR TITLE
Language support improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.39.0, stable]
+        rust: [1.40.0, stable]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -159,7 +159,7 @@ impl Cache {
     pub fn find_page(&self, name: &str, languages: &[String]) -> Option<PathBuf> {
         let page_filename = format!("{}.md", name);
 
-        // Get platform dir
+        // Get cache dir
         let cache_dir = match Self::get_cache_dir() {
             Ok(cache_dir) => cache_dir.join("tldr-master"),
             Err(e) => {

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -1,0 +1,22 @@
+/// An extension trait to clear duplicates from a collection.
+pub(crate) trait Dedup<T: PartialEq + Clone> {
+    fn clear_duplicates(&mut self);
+}
+
+/// Clear duplicates from a collection, keep the first one seen.
+///
+/// For small vectors, this will be faster than a `HashSet`.
+/// Based on <https://stackoverflow.com/a/57889826/284318>
+impl<T: PartialEq + Clone> Dedup<T> for Vec<T> {
+    fn clear_duplicates(&mut self) {
+        let mut already_seen = Vec::with_capacity(self.len());
+        self.retain(|item| {
+            if already_seen.contains(item) {
+                false
+            } else {
+                already_seen.push(item.clone());
+                true
+            }
+        })
+    }
+}

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 /// An extension trait to clear duplicates from a collection.
 pub(crate) trait Dedup<T: PartialEq + Clone> {
     fn clear_duplicates(&mut self);
@@ -6,17 +8,13 @@ pub(crate) trait Dedup<T: PartialEq + Clone> {
 /// Clear duplicates from a collection, keep the first one seen.
 ///
 /// For small vectors, this will be faster than a `HashSet`.
-/// Based on <https://stackoverflow.com/a/57889826/284318>
 impl<T: PartialEq + Clone> Dedup<T> for Vec<T> {
     fn clear_duplicates(&mut self) {
-        let mut already_seen = Vec::with_capacity(self.len());
-        self.retain(|item| {
-            if already_seen.contains(item) {
-                false
-            } else {
-                already_seen.push(item.clone());
-                true
+        let orig = mem::replace(self, Vec::with_capacity(self.len()));
+        for item in orig {
+            if !self.contains(&item) {
+                self.push(item);
             }
-        })
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,46 +478,50 @@ mod test {
         assert!(!test_helper(&argv).is_ok());
     }
 
-    #[test]
-    fn test_language_missing_lang_env() {
-        let lang_list = get_languages(Err(std::env::VarError::NotPresent), Ok("de:fr".into()));
-        assert_eq!(lang_list, vec!["en"]);
-        let lang_list = get_languages(
-            Err(std::env::VarError::NotPresent),
-            Err(std::env::VarError::NotPresent),
-        );
-        assert_eq!(lang_list, vec!["en"]);
-    }
+    mod language {
+        use super::*;
 
-    #[test]
-    fn test_language_missing_language_env() {
-        let lang_list = get_languages(Ok("de".into()), Err(std::env::VarError::NotPresent));
-        assert_eq!(lang_list, vec!["de", "en"]);
-    }
+        #[test]
+        fn missing_lang_env() {
+            let lang_list = get_languages(Err(std::env::VarError::NotPresent), Ok("de:fr".into()));
+            assert_eq!(lang_list, vec!["en"]);
+            let lang_list = get_languages(
+                Err(std::env::VarError::NotPresent),
+                Err(std::env::VarError::NotPresent),
+            );
+            assert_eq!(lang_list, vec!["en"]);
+        }
 
-    #[test]
-    fn test_language_preference_order() {
-        let lang_list = get_languages(Ok("de".into()), Ok("fr:cn".into()));
-        assert_eq!(lang_list, vec!["fr", "cn", "de", "en"]);
-    }
+        #[test]
+        fn missing_language_env() {
+            let lang_list = get_languages(Ok("de".into()), Err(std::env::VarError::NotPresent));
+            assert_eq!(lang_list, vec!["de", "en"]);
+        }
 
-    #[test]
-    fn test_language_country_code_expansion() {
-        let lang_list = get_languages(Ok("pt_BR".into()), Err(std::env::VarError::NotPresent));
-        assert_eq!(lang_list, vec!["pt_BR", "pt", "en"]);
-    }
+        #[test]
+        fn preference_order() {
+            let lang_list = get_languages(Ok("de".into()), Ok("fr:cn".into()));
+            assert_eq!(lang_list, vec!["fr", "cn", "de", "en"]);
+        }
 
-    #[test]
-    fn test_language_ignore_posix_and_c() {
-        let lang_list = get_languages(Ok("POSIX".into()), Err(std::env::VarError::NotPresent));
-        assert_eq!(lang_list, vec!["en"]);
-        let lang_list = get_languages(Ok("C".into()), Err(std::env::VarError::NotPresent));
-        assert_eq!(lang_list, vec!["en"]);
-    }
+        #[test]
+        fn country_code_expansion() {
+            let lang_list = get_languages(Ok("pt_BR".into()), Err(std::env::VarError::NotPresent));
+            assert_eq!(lang_list, vec!["pt_BR", "pt", "en"]);
+        }
 
-    #[test]
-    fn test_language_no_duplicates() {
-        let lang_list = get_languages(Ok("de".into()), Ok("fr:de:cn:de".into()));
-        assert_eq!(lang_list, vec!["fr", "de", "cn", "en"]);
+        #[test]
+        fn ignore_posix_and_c() {
+            let lang_list = get_languages(Ok("POSIX".into()), Err(std::env::VarError::NotPresent));
+            assert_eq!(lang_list, vec!["en"]);
+            let lang_list = get_languages(Ok("C".into()), Err(std::env::VarError::NotPresent));
+            assert_eq!(lang_list, vec!["en"]);
+        }
+
+        #[test]
+        fn no_duplicates() {
+            let lang_list = get_languages(Ok("de".into()), Ok("fr:de:cn:de".into()));
+            assert_eq!(lang_list, vec!["fr", "de", "cn", "en"]);
+        }
     }
 }


### PR DESCRIPTION
After #125, I used the occasion to dig out valgrind and kcachegrind to do some performance optimization (something that's fun, but that I do way too seldom...)

To profile, I created a new standalone binary that included nothing but `get_languages` and this `main`:

```rust
fn main() {
    get_languages(Some("en_US.utf8".to_string()), Some("de:en:fr".to_string()));
}
```

I then built in release mode and counted the instructions for `main` (since the function call to `get_languages` was inlined).

Results (in CPU instructions and percentage reduced compared to previous version):

- Initial: 6939 (100%)
- Replace `HashSet` for deduplication with linear search based approach: 4801 (-31%)
- Do not allocate `language` variable: 4796 (-0.1%)
- Avoid processing fallback language by inserting it directly into `lang_list`, not `locales`: 4543 (-5.3%)
- Do not collect `locales` into intermediate vec, instead use a chained iterator: 3900 (-14.2%)

Callees before and after:

![before](https://user-images.githubusercontent.com/105168/106216012-78a46c00-61d2-11eb-9c3d-91838e898d56.png)

![after](https://user-images.githubusercontent.com/105168/106216018-7b06c600-61d2-11eb-976d-0337d890ffad.png)

All in all, a reduction in instruction count (for the specified env variables) by 44%, nice!

(Might be of interest to you, @niklasmohrin)