### PR TITLE
zsh-completion: fix issue with [.md, add basic -L completion, remove extra _files args

### DIFF
--- a/zsh_tealdeer
+++ b/zsh_tealdeer
@@ -1,7 +1,9 @@
 #compdef tldr
 
 _applications() {
-  _values 'applications' "${(uonzf)$(tldr --list | sed -e 's/, /\n/g')}"
+    local -a commands
+    commands=(${(uonzf)"$(tldr --list 2>/dev/null)"//:/\\:})
+    _describe -t commands 'command' commands
 }
 
 _tealdeer() {
@@ -18,6 +20,7 @@ _tealdeer() {
             sunos
             windows
         ))'
+        "($I -L --language)"{-L,--language}"[Override the language settings]:lang"
         "($I -u --update)"{-u,--update}"[Update the local cache]"
         "($I -c --clear-cache)"{-c,--clear-cache}"[Clear the local cache]"
         "($I -p --pager)"{-p,--pager}"[Use a pager to page output]"
@@ -31,8 +34,7 @@ _tealdeer() {
             never
         ))"
         '(- *)'{-h,--help}'[Display help]'
-            '(- *)'{-v,--version}'[Show version information]'
-            '*:file:_files'
+        '(- *)'{-v,--version}'[Show version information]'
         '1: :_applications'
     )
 


### PR DESCRIPTION
Changes information:
- Use array `commands=(...)` and `_describe` to deal with '[.md' & empty cache scenario.  Fixes #166
- Hide `tldr --list` stderr (`2>/dev/null`) which breaks completion with empty cache
- Remove `sed` since #112 changed commas to newlines
- Add new `sed`-equivalent replacement (`:` -> `\:`) using native [ZSH `${name//pattern/repl}`](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion) since colon is special character in ZSH completions
- Add basic support for `-L, --language` flag from #125. In future, can consider adding extra completions maybe based on caches `pages.{lang}` folders.
- Remove extraneous completion of file names for positional arguments (i.e. `'*:file:_files'`)

The following are output from ZSH 5.8 with locally built master branch.

---

Some errors shown with original completions:
1. [.md:
    <img width="545" alt="error-1" src="https://user-images.githubusercontent.com/20700669/111734199-dbab9a00-8836-11eb-8ec9-f1b55429695e.png">

2. Empty cache stderr:
    <img width="768" alt="error-2" src="https://user-images.githubusercontent.com/20700669/111734105-a56e1a80-8836-11eb-8b38-8a2824e92cdf.png">

---

Output of ZSH with new completions
1. No issue with [.md:
    <img width="635" alt="output1" src="https://user-images.githubusercontent.com/20700669/111733620-8f138f00-8835-11eb-884b-4d9cf922dac2.png">


2. Empty cache, no completions shown (ignore dimmed font due to zsh-autosuggestions plugin):
    <img width="719" alt="output2" src="https://user-images.githubusercontent.com/20700669/111733719-c5e9a500-8835-11eb-9a7e-769ec979ba27.png">

3. Empty cache, flag completions after `-`:
    <img width="558" alt="output3" src="https://user-images.githubusercontent.com/20700669/111733797-ee719f00-8835-11eb-83b7-80f2b1b381cc.png">
