### PR TITLE
Send all progress logging messages to stderr.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn update_cache(cache: &Cache, quietly: bool) {
         process::exit(1);
     });
     if !quietly {
-        println!("Successfully updated cache.");
+        eprintln!("Successfully updated cache.");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn clear_cache(quietly: bool) {
         process::exit(1);
     });
     if !quietly {
-        println!("Successfully deleted cache.");
+        eprintln!("Successfully deleted cache.");
     }
 }
 
@@ -239,7 +239,7 @@ fn show_paths() {
 fn create_config_and_exit() {
     match make_default_config() {
         Ok(config_file_path) => {
-            println!(
+            eprintln!(
                 "Successfully created seed config file here: {}",
                 config_file_path.to_str().unwrap()
             );
@@ -484,9 +484,9 @@ fn main() {
             }
         } else {
             if !args.flag_quiet {
-                println!("Page {} not found in cache", &command);
-                println!("Try updating with `tldr --update`, or submit a pull request to:");
-                println!("https://github.com/tldr-pages/tldr");
+                eprintln!("Page {} not found in cache", &command);
+                eprintln!("Try updating with `tldr --update`, or submit a pull request to:");
+                eprintln!("https://github.com/tldr-pages/tldr");
             }
             process::exit(1);
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -115,7 +115,7 @@ fn test_update_cache() {
         .args(&["--update"])
         .assert()
         .success()
-        .stdout(contains("Successfully updated cache."));
+        .stderr(contains("Successfully updated cache."));
 
     testenv.command().args(&["sl"]).assert().success();
 }
@@ -198,7 +198,7 @@ fn test_setup_seed_config() {
         .args(&["--seed-config"])
         .assert()
         .success()
-        .stdout(contains("Successfully created seed config file"));
+        .stderr(contains("Successfully created seed config file here"));
 }
 
 #[test]
@@ -242,12 +242,7 @@ fn test_show_paths() {
 fn test_markdown_rendering() {
     let testenv = TestEnv::new();
 
-    testenv
-        .command()
-        .args(&["--update"])
-        .assert()
-        .success()
-        .stdout(contains("Successfully updated cache."));
+    testenv.add_entry("tar", include_str!("tar-markdown.expected"));
 
     let expected = include_str!("tar-markdown.expected");
     testenv
@@ -368,7 +363,7 @@ fn test_spaces_find_command() {
         .args(&["--update"])
         .assert()
         .success()
-        .stdout(contains("Successfully updated cache."));
+        .stderr(contains("Successfully updated cache."));
 
     testenv
         .command()
@@ -386,7 +381,7 @@ fn test_pager_flag_enable() {
         .args(&["--update"])
         .assert()
         .success()
-        .stdout(contains("Successfully updated cache."));
+        .stderr(contains("Successfully updated cache."));
 
     testenv
         .command()
@@ -455,9 +450,9 @@ fn test_autoupdate_cache() {
         let assert = testenv.command().args(&["--list"]).assert().success();
         let pred = contains("Successfully updated cache");
         if expected {
-            assert.stdout(pred)
+            assert.stderr(pred)
         } else {
-            assert.stdout(pred.not())
+            assert.stderr(pred.not())
         };
     };
 
@@ -492,7 +487,7 @@ fn test_pager_warning() {
         .args(&["--update"])
         .assert()
         .success()
-        .stdout(contains("Successfully updated cache."));
+        .stderr(contains("Successfully updated cache."));
 
     // Regular call should not show a "pager flag not available on windows" warning
     testenv


### PR DESCRIPTION
Adresses #169. 

- Send logging messages to stderr instead of stdout so pagers do not intercept them.
- Updated tests to match these changes.
- Changed test_markdown_rendering to no longer rely on the tldr pages
       repo. Instead manually adding a known page to use in this test,
       because it failed due to the tldr pages repo updating this command (so
       it no longer matched our expected output, which shouldn't cause our
       tests to fail).