### PR TITLE
Remove 'extern crate' declarations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,6 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::too_many_lines)]
 
-#[cfg(feature = "logging")]
-extern crate env_logger;
-
 use std::env;
 use std::fs::File;
 use std::io::BufRead;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,11 +1,5 @@
 //! Integration tests.
 
-extern crate assert_cmd;
-extern crate escargot;
-extern crate filetime;
-extern crate predicates;
-extern crate tempfile;
-
 use std::fs::{create_dir_all, File};
 use std::io::Write;
 use std::process::Command;


### PR DESCRIPTION
Cargo.toml specifies Rust Edition 2018 which does not require 'extern crate' anymore.