### PR TITLE
fix check warn

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,8 +24,8 @@ fn default_bold() -> bool {
     false
 }
 
-#[serde(rename_all = "lowercase")]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
 pub enum RawColor {
     Black,
     Red,


### PR DESCRIPTION
```
warning: derive helper attribute is used before it is introduced
  --> src/config.rs:27:3
   |
27 | #[serde(rename_all = "lowercase")]
   |   ^^^^^
28 | #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
   |                              --------- the attribute is introduced here
   |
   = note: `#[warn(legacy_derive_helpers)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
```