### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ const ARCHIVE_URL: &str = "https://github.com/tldr-pages/tldr/archive/master.tar
 #[cfg(not(target_os = "windows"))]
 const PAGER_COMMAND: &str = "less -R";
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
 struct Args {
     arg_command: Option<Vec<String>>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,6 +108,8 @@ pub enum PathSource {
     OsConvention,
     /// Env variable (TEALDEER_*)
     EnvVar,
+
+    #[allow(dead_code)]
     /// Config file variable
     ConfigVar,
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -40,7 +40,7 @@ impl TestEnv {
         println!("Config path: {:?}", &config_file_name);
 
         let mut config_file = File::create(&config_file_name).unwrap();
-        config_file.write(content.as_ref().as_bytes()).unwrap();
+        config_file.write_all(content.as_ref().as_bytes()).unwrap();
     }
 
     /// Add entry for that environment to the "common" pages.
@@ -379,7 +379,7 @@ fn test_correct_rendering_with_config() {
 
     let mut config_file = File::create(&config_file_path).unwrap();
     config_file
-        .write(include_str!("config.toml").as_bytes())
+        .write_all(include_str!("config.toml").as_bytes())
         .unwrap();
 
     // Create input file
@@ -487,7 +487,7 @@ fn test_autoupdate_cache() {
     // Activate automatic updates, set the auto-update interval to 24 hours
     let mut config_file = File::create(&config_file_path).unwrap();
     config_file
-        .write("[updates]\nauto_update = true\nauto_update_interval_hours = 24".as_bytes())
+        .write_all("[updates]\nauto_update = true\nauto_update_interval_hours = 24".as_bytes())
         .unwrap();
     config_file.flush().unwrap();
 


### PR DESCRIPTION
  - allow struct excessive bools for Args struct.
  - change tests to use write_all instead of write
  - allow dead_code for the ConvigVar variant of PathSource