### PR TITLE
Remove aur links for `tealdeer` and `tealdeer-bin`

### DIFF
--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -14,9 +14,7 @@ autocompletions](#autocompletion).
 
 Tealdeer has been added to a few package managers:
 
-- Arch Linux AUR: [`tealdeer`](https://aur.archlinux.org/packages/tealdeer/),
-  [`tealdeer-bin`](https://aur.archlinux.org/packages/tealdeer-bin/) or
-  [`tealdeer-git`](https://aur.archlinux.org/packages/tealdeer-git/)
+- Arch Linux AUR: [`tealdeer-git`](https://aur.archlinux.org/packages/tealdeer-git/)
 - Fedora: [`tealdeer`](https://src.fedoraproject.org/rpms/rust-tealdeer)
 - FreeBSD: [`sysutils/tealdeer`](https://www.freshports.org/sysutils/tealdeer/)
 - Homebrew: [`tealdeer`](https://formulae.brew.sh/formula/tealdeer)

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -14,7 +14,7 @@ autocompletions](#autocompletion).
 
 Tealdeer has been added to a few package managers:
 
-- Arch Linux AUR: [`tealdeer-git`](https://aur.archlinux.org/packages/tealdeer-git/)
+- Arch Linux: [`tealdeer`](https://archlinux.org/packages/community/x86_64/tealdeer/)
 - Fedora: [`tealdeer`](https://src.fedoraproject.org/rpms/rust-tealdeer)
 - FreeBSD: [`sysutils/tealdeer`](https://www.freshports.org/sysutils/tealdeer/)
 - Homebrew: [`tealdeer`](https://formulae.brew.sh/formula/tealdeer)


### PR DESCRIPTION
These packages have been removed from AUR, only `tealdeer-git` exists now.

404ing pages:
https://aur.archlinux.org/pkgbase/tealdeer/
https://aur.archlinux.org/pkgbase/tealdeer-bin/
