### PR TITLE
Implement support for italics

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,10 @@ fn default_bold() -> bool {
     false
 }
 
+fn default_italic() -> bool {
+    false
+}
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum RawColor {
@@ -64,6 +68,8 @@ struct RawStyle {
     pub underline: bool,
     #[serde(default = "default_bold")]
     pub bold: bool,
+    #[serde(default = "default_italic")]
+    pub italic: bool,
 }
 
 impl Default for RawStyle {
@@ -73,6 +79,7 @@ impl Default for RawStyle {
             background: None,
             underline: false,
             bold: false,
+            italic: false,
         }
     }
 } // impl RawStyle
@@ -95,6 +102,10 @@ impl From<RawStyle> for Style {
 
         if raw_style.bold {
             style = style.bold();
+        }
+
+        if raw_style.italic {
+            style = style.italic();
         }
 
         style

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -18,6 +18,7 @@ underline = false
 [style.example_variable]
 underline = true
 bold = false
+italic = true
 
 [display]
 use_pager = false

--- a/tests/inkscape-with-config.expected
+++ b/tests/inkscape-with-config.expected
@@ -4,27 +4,27 @@
 
   [44;30mOpen an SVG file in the Inkscape GUI:[0m
 
-      [1minkscape[0m [4mfilename.svg[0m
+      [1minkscape[0m [3;4mfilename.svg[0m
 
   [44;30mExport an SVG file into a bitmap with the default format (PNG) and the default resolution (90 DPI):[0m
 
-      [1minkscape[0m [4mfilename.svg[0m -e [4mfilename.png[0m
+      [1minkscape[0m [3;4mfilename.svg[0m -e [3;4mfilename.png[0m
 
   [44;30mExport an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):[0m
 
-      [1minkscape[0m [4mfilename.svg[0m -e [4mfilename.png[0m -w [4m600[0m -h [4m400[0m
+      [1minkscape[0m [3;4mfilename.svg[0m -e [3;4mfilename.png[0m -w [3;4m600[0m -h [3;4m400[0m
 
   [44;30mExport a single object, given its ID, into a bitmap:[0m
 
-      [1minkscape[0m [4mfilename.svg[0m -i [4mid[0m -e [4mobject.png[0m
+      [1minkscape[0m [3;4mfilename.svg[0m -i [3;4mid[0m -e [3;4mobject.png[0m
 
   [44;30mExport an SVG document to PDF, converting all texts to paths:[0m
 
-      [1minkscape[0m [4mfilename.svg[0m | [1minkscape[0m | [1minkscape[0m --export-pdf=[4minkscape.pdf[0m | [1minkscape[0m | [1minkscape[0m --export-text-to-path
+      [1minkscape[0m [3;4mfilename.svg[0m | [1minkscape[0m | [1minkscape[0m --export-pdf=[3;4minkscape.pdf[0m | [1minkscape[0m | [1minkscape[0m --export-text-to-path
 
   [44;30mDuplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:[0m
 
-      [1minkscape[0m [4mfilename.svg[0m --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
+      [1minkscape[0m [3;4mfilename.svg[0m --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
 
   [44;30mSome invalid command just to test the correct highlighting of the command name:[0m
 


### PR DESCRIPTION
Adds a configuration option for displaying information with the italics style. 

Fixes #146 

Before: 
![image](https://user-images.githubusercontent.com/12008100/127478373-cd6dc7d1-dfdf-43c2-a776-64d5483fcdbe.png)

After (configured example_variable to use italic instead of underline):
![image](https://user-images.githubusercontent.com/12008100/127478551-5a4ddb7d-0c96-4d5d-85f5-646f8434632e.png)

