### PR TITLE
Use default style if user-defined style is missing.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,7 @@ impl Default for RawConfig {
             style: RawStyleConfig::default(),
             display: RawDisplayConfig::default(),
             updates: RawUpdatesConfig::default(),
-            directories: RawDirectoriesConfig::default()
+            directories: RawDirectoriesConfig::default(),
         };
 
         // Set default config


### PR DESCRIPTION
Changes the serde configuration of the `RawConfig` struct to utilize a custom `Default` implementation to initialize new objects.

This implementation contains the default style set as it was previously provided through the implementation of `RawConfig::new()`, and therefore, allows to utilize the default configuration until the user overwrites the related `RawStyleConfig` field, e.g. the description highlighting.

.. fixes #149