### PR TITLE
Add "macos" alias for "osx"

### DIFF
--- a/bash_tealdeer
+++ b/bash_tealdeer
@@ -14,7 +14,7 @@ _tealdeer()
 			return
 			;;
 		-p|--platform)
-			COMPREPLY=( $(compgen -W 'linux osx sunos windows' -- "${cur}") )
+			COMPREPLY=( $(compgen -W 'linux macos sunos windows' -- "${cur}") )
 			return
 			;;
 		--color)

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -13,10 +13,9 @@ ARGS:
 OPTIONS:
     -l, --list                   List all commands in the cache
     -f, --render <FILE>          Render a specific markdown file
-    -p, --platform <PLATFORM>    Override the operating system [possible values: linux, osx, sunos,
-                                 windows]
-    -o, --os <OS>                Deprecated alias of `platform` [possible values: linux, osx, sunos,
-                                 windows]
+    -p, --platform <PLATFORM>    Override the operating system [possible values: linux, macos,
+                                 windows, sunos, osx]
+    -o, --os <OS>                Deprecated alias of `platform`
     -L, --language <LANGUAGE>    Override the language
     -u, --update                 Update the local cache
     -c, --clear-cache            Clear the local cache

--- a/fish_tealdeer
+++ b/fish_tealdeer
@@ -7,7 +7,7 @@ complete -c tldr -s h -l help        -d 'Print the help message.' -f
 complete -c tldr -s v -l version     -d 'Show version information.' -f
 complete -c tldr -s l -l list        -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render      -d 'Render a specific markdown file.' -r
-complete -c tldr -s p -l platform    -d 'Override the operating system.' -xa 'linux osx sunos windows'
+complete -c tldr -s p -l platform    -d 'Override the operating system.' -xa 'linux macos sunos windows'
 complete -c tldr -s u -l update      -d 'Update the local cache.' -f
 complete -c tldr -s c -l clear-cache -d 'Clear the local cache.' -f
 complete -c tldr -s p -l pager       -d 'Use a pager to page output.' -f

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ struct Args {
         short = 'p',
         long = "platform",
         requires = "command",
-        possible_values = ["linux", "osx", "sunos", "windows"],
+        possible_values = ["linux", "macos", "windows", "sunos", "osx"],
     )]
     platform: Option<PlatformType>,
 
@@ -93,7 +93,8 @@ struct Args {
         short = 'o',
         long = "os",
         requires = "command",
-        possible_values = ["linux", "osx", "sunos", "windows"],
+        possible_values = ["linux", "macos", "windows", "sunos", "osx"],
+        hide_possible_values = true,
     )]
     os: Option<PlatformType>,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,11 +31,11 @@ impl str::FromStr for PlatformType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "linux" => Ok(Self::Linux),
-            "osx" => Ok(Self::OsX),
+            "osx" | "macos" => Ok(Self::OsX),
             "sunos" => Ok(Self::SunOs),
             "windows" => Ok(Self::Windows),
             other => Err(format!(
-                "Unknown OS: {}. Possible values: linux, osx, sunos, windows",
+                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows",
                 other
             )),
         }

--- a/zsh_tealdeer
+++ b/zsh_tealdeer
@@ -16,7 +16,7 @@ _tealdeer() {
         "($I -f --render)"{-f,--render}"[Render a specific markdown file]:file:_files"
         "($I -p --platform)"{-p,--platform}'[Override the operating system]:platform:((
             linux
-            osx
+            macos
             sunos
             windows
         ))'


### PR DESCRIPTION
The Apple computer operating system was renamed from "OS X" to "macOS" in 2016. We should accept "macos" in addition to "osx" in all our CLI APIs, and the docs should also mention this alias instead of "osx".

For backwards compatibility and for compatibility with the tldr client specification, we should still accept "osx" though.