### PR TITLE
Rename `-o / --os` to `-p / --platform`

### DIFF
--- a/bash_tealdeer
+++ b/bash_tealdeer
@@ -13,7 +13,7 @@ _tealdeer()
 			_filedir
 			return
 			;;
-		-o|--os)
+		-p|--platform)
 			COMPREPLY=( $(compgen -W 'linux osx sunos windows' -- "${cur}") )
 			return
 			;;

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -13,12 +13,14 @@ ARGS:
 OPTIONS:
     -l, --list                   List all commands in the cache
     -f, --render <FILE>          Render a specific markdown file
-    -o, --os <OS>                Override the operating system [possible values: linux, osx, sunos,
+    -p, --platform <PLATFORM>    Override the operating system [possible values: linux, osx, sunos,
+                                 windows]
+    -o, --os <OS>                Deprecated alias of `platform` [possible values: linux, osx, sunos,
                                  windows]
     -L, --language <LANGUAGE>    Override the language
     -u, --update                 Update the local cache
     -c, --clear-cache            Clear the local cache
-    -p, --pager                  Use a pager to page output
+        --pager                  Use a pager to page output
     -r, --raw                    Display the raw markdown instead of rendering it
     -q, --quiet                  Suppress informational messages
         --show-paths             Show file and directory paths used by tealdeer

--- a/fish_tealdeer
+++ b/fish_tealdeer
@@ -7,7 +7,7 @@ complete -c tldr -s h -l help        -d 'Print the help message.' -f
 complete -c tldr -s v -l version     -d 'Show version information.' -f
 complete -c tldr -s l -l list        -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render      -d 'Render a specific markdown file.' -r
-complete -c tldr -s o -l os          -d 'Override the operating system.' -xa 'linux osx sunos windows'
+complete -c tldr -s p -l platform    -d 'Override the operating system.' -xa 'linux osx sunos windows'
 complete -c tldr -s u -l update      -d 'Update the local cache.' -f
 complete -c tldr -s c -l clear-cache -d 'Clear the local cache.' -f
 complete -c tldr -s p -l pager       -d 'Use a pager to page output.' -f

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -16,7 +16,7 @@ use zip::ZipArchive;
 
 use crate::{
     error::TealdeerError::{self, CacheError, UpdateError},
-    types::{OsType, PathSource},
+    types::{PathSource, PlatformType},
 };
 
 static CACHE_DIR_ENV_VAR: &str = "TEALDEER_CACHE_DIR";
@@ -27,7 +27,7 @@ static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
 #[derive(Debug)]
 pub struct Cache {
     url: String,
-    os: OsType,
+    platform: PlatformType,
 }
 
 #[derive(Debug)]
@@ -64,13 +64,13 @@ pub enum CacheFreshness {
 }
 
 impl Cache {
-    pub fn new<S>(url: S, os: OsType) -> Self
+    pub fn new<S>(url: S, platform: PlatformType) -> Self
     where
         S: Into<String>,
     {
         Self {
             url: url.into(),
-            os,
+            platform,
         }
     }
 
@@ -196,11 +196,11 @@ impl Cache {
 
     /// Return the platform directory.
     fn get_platform_dir(&self) -> &'static str {
-        match self.os {
-            OsType::Linux => "linux",
-            OsType::OsX => "osx",
-            OsType::SunOs => "sunos",
-            OsType::Windows => "windows",
+        match self.platform {
+            PlatformType::Linux => "linux",
+            PlatformType::OsX => "osx",
+            PlatformType::SunOs => "sunos",
+            PlatformType::Windows => "windows",
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,14 +7,14 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)]
-pub enum OsType {
+pub enum PlatformType {
     Linux,
     OsX,
     SunOs,
     Windows,
 }
 
-impl fmt::Display for OsType {
+impl fmt::Display for PlatformType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Linux => write!(f, "Linux"),
@@ -25,7 +25,7 @@ impl fmt::Display for OsType {
     }
 }
 
-impl str::FromStr for OsType {
+impl str::FromStr for PlatformType {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -42,7 +42,7 @@ impl str::FromStr for OsType {
     }
 }
 
-impl OsType {
+impl PlatformType {
     #[cfg(target_os = "linux")]
     pub fn current() -> Self {
         Self::Linux

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -325,7 +325,7 @@ fn test_os_specific_page() {
 
     testenv
         .command()
-        .args(["--os", "sunos", "truss"])
+        .args(["--platform", "sunos", "truss"])
         .assert()
         .success();
 }
@@ -685,7 +685,7 @@ fn test_pager_warning() {
     // But it should be shown if the pager flag is true
     testenv
         .command()
-        .args(["which", "-p"])
+        .args(["--pager", "which"])
         .assert()
         .success()
         .stderr(contains("pager flag not available on Windows"));

--- a/zsh_tealdeer
+++ b/zsh_tealdeer
@@ -14,7 +14,7 @@ _tealdeer() {
     args+=(
         "($I -l --list)"{-l,--list}"[List all commands in the cache]"
         "($I -f --render)"{-f,--render}"[Render a specific markdown file]:file:_files"
-        "($I -o --os)"{-o,--os}'[Override the operating system]:os:((
+        "($I -p --platform)"{-p,--platform}'[Override the operating system]:platform:((
             linux
             osx
             sunos


### PR DESCRIPTION
This makes it compliant with the client spec (see #209).

The `-p` flag was previously used for the pager, using the pager now requires using the long flag (`--pager`). Alternatively the pager can be configured through the config file.