### PR TITLE
Lowercase page names before lookup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -493,7 +493,10 @@ fn main() {
 
     // Show command from cache
     if !args.command.is_empty() {
-        let command = args.command.join("-");
+        // Note: According to the TLDR client spec, page names must be transparently
+        // lowercased before lookup:
+        // https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#page-names
+        let command = args.command.join("-").to_lowercase();
 
         let languages = args
             .language

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -690,3 +690,22 @@ fn test_pager_warning() {
         .success()
         .stderr(contains("pager flag not available on Windows"));
 }
+
+/// Ensure that page lookup is case insensitive, so a page lookup for `eyed3`
+/// and `eyeD3` should return the same page.
+#[test]
+fn test_lowercased_page_lookup() {
+    let testenv = TestEnv::new();
+
+    // Lookup `eyed3`, initially fails
+    testenv.command().args(["eyed3"]).assert().failure();
+
+    // Add entry
+    testenv.add_entry("eyed3", "contents");
+
+    // Lookup `eyed3` again
+    testenv.command().args(["eyed3"]).assert().success();
+
+    // Lookup `eyeD3`, should succeed as well
+    testenv.command().args(["eyeD3"]).assert().success();
+}


### PR DESCRIPTION
This adds another allocation that wasn't necessary before, but the overhead is totally negligible.

Part of #209.