### PR TITLE
Custom pages in show paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,10 @@ impl Default for RawDirectoriesConfig {
     fn default() -> Self {
         Self {
             custom_pages_dir: get_app_root(AppDataType::UserData, &crate::APP_INFO)
-                .map(|path| path.join("pages"))
+                .map(|path| {
+                    // Note: The `join("")` call ensures that there's a trailing slash
+                    path.join("pages").join("")
+                })
                 .ok(),
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -284,17 +284,18 @@ fn test_setup_seed_config() {
 fn test_show_paths() {
     let testenv = TestEnv::new();
 
+    // Show general commands
     testenv
         .command()
         .args(["--show-paths"])
         .assert()
         .success()
         .stdout(contains(format!(
-            "Config dir:  {}",
+            "Config dir:       {}",
             testenv.config_dir.path().to_str().unwrap(),
         )))
         .stdout(contains(format!(
-            "Config path: {}",
+            "Config path:      {}",
             testenv
                 .config_dir
                 .path()
@@ -303,17 +304,34 @@ fn test_show_paths() {
                 .unwrap(),
         )))
         .stdout(contains(format!(
-            "Cache dir:   {}",
+            "Cache dir:        {}",
             testenv.cache_dir.path().to_str().unwrap(),
         )))
         .stdout(contains(format!(
-            "Pages dir:   {}",
+            "Pages dir:        {}",
             testenv
                 .cache_dir
                 .path()
                 .join(TLDR_PAGES_DIR)
                 .to_str()
                 .unwrap(),
+        )));
+
+    // Set custom pages directory
+    testenv.write_config(format!(
+        "[directories]\ncustom_pages_dir = '{}'",
+        testenv.custom_pages_dir.path().to_str().unwrap()
+    ));
+
+    // Now ensure that this path is contained in the output
+    testenv
+        .command()
+        .args(["--show-paths"])
+        .assert()
+        .success()
+        .stdout(contains(format!(
+            "Custom pages dir: {}",
+            testenv.custom_pages_dir.path().to_str().unwrap(),
         )));
 }
 


### PR DESCRIPTION
A simpler version of #184 that doesn't change the config structure or file lookup logic.

Fixes #182.