### PR TITLE
Concatenate page and patch bytes before processing

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,7 +4,7 @@
 
 - [Installing](./installing.md)
 - [Usage](./usage.md)
-  - [Custom Pages](./usage_custom_pages.md)
+  - [Custom Pages and Patches](./usage_custom_pages.md)
 - [Configuration](./config.md)
   - [Section: \[display\]](./config_display.md)
   - [Section: \[style\]](./config_style.md)

--- a/docs/src/usage_custom_pages.md
+++ b/docs/src/usage_custom_pages.md
@@ -4,7 +4,7 @@ Tealdeer allows creating new custom pages, overriding existing pages as well as
 extending existing pages.
 
 The directory, where these custom pages and patches can be placed, follows OS
-conventions. On Linux, for example, the default location is
+conventions. On Linux for instance, the default location is
 `~/.local/share/tealdeer/pages/`. To print the path used on your system, simply
 run `tldr --show-paths`.
 
@@ -32,6 +32,9 @@ Sometimes you don't want to fully replace an existing upstream page, but just
 want to extend it with your own examples that you frequently need. In this
 case, use a file called `<command>.patch`, it will be appended to existing
 pages.
+
+> **Note:** Because the patch file will be concatenated directly to the page
+> file, it needs to start with an empty line.
 
 Path:
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,9 +1,8 @@
 use std::{
     env,
     ffi::OsStr,
-    fs,
-    io::{Cursor, Read, Seek},
-    iter,
+    fs::{self, File},
+    io::{BufReader, Cursor, Read, Seek},
     path::{Path, PathBuf},
 };
 
@@ -32,8 +31,8 @@ pub struct Cache {
 
 #[derive(Debug)]
 pub struct PageLookupResult {
-    page_path: PathBuf,
-    patch_path: Option<PathBuf>,
+    pub page_path: PathBuf,
+    pub patch_path: Option<PathBuf>,
 }
 
 impl PageLookupResult {
@@ -49,8 +48,36 @@ impl PageLookupResult {
         self
     }
 
-    pub fn paths(&self) -> impl Iterator<Item = &Path> {
-        iter::once(self.page_path.as_path()).chain(self.patch_path.as_deref())
+    /// Create a buffered reader that sequentially reads from the page and the
+    /// patch, as if they were concatenated.
+    ///
+    /// This will return an error if either the page file or the patch file
+    /// cannot be opened.
+    pub fn reader(&self) -> Result<BufReader<Box<dyn Read>>, String> {
+        // Open page file
+        let page_file = File::open(&self.page_path)
+            .map_err(|msg| format!("Could not open page file at {:?}: {}", self.page_path, msg))?;
+
+        // Open patch file
+        let patch_file_opt = match &self.patch_path {
+            Some(path) => Some(
+                File::open(path)
+                    .map_err(|msg| format!("Could not open patch file at {:?}: {}", path, msg))?,
+            ),
+            None => None,
+        };
+
+        // Create chained reader from file(s)
+        //
+        // Note: It might be worthwhile to create our own struct that accepts
+        // the page and patch files and that will read them sequentially,
+        // because it avoids the boxing below. However, the performance impact
+        // would first need to be shown to be significant using a benchmark.
+        Ok(BufReader::new(if let Some(patch_file) = patch_file_opt {
+            Box::new(page_file.chain(patch_file)) as Box<dyn Read>
+        } else {
+            Box::new(page_file) as Box<dyn Read>
+        }))
     }
 }
 
@@ -360,23 +387,4 @@ impl Cache {
 /// Unit Tests for cache module
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[test]
-    fn test_page_lookup_result_iter_with_patch() {
-        let lookup = PageLookupResult::with_page(PathBuf::from("test.page"))
-            .with_optional_patch(Some(PathBuf::from("test.patch")));
-        let mut iter = lookup.paths();
-        assert_eq!(iter.next(), Some(Path::new("test.page")));
-        assert_eq!(iter.next(), Some(Path::new("test.patch")));
-        assert_eq!(iter.next(), None);
-    }
-
-    #[test]
-    fn test_page_lookup_result_iter_no_patch() {
-        let lookup = PageLookupResult::with_page(PathBuf::from("test.page"));
-        let mut iter = lookup.paths();
-        assert_eq!(iter.next(), Some(Path::new("test.page")));
-        assert_eq!(iter.next(), None);
-    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -74,7 +74,7 @@ impl PageLookupResult {
         // because it avoids the boxing below. However, the performance impact
         // would first need to be shown to be significant using a benchmark.
         Ok(BufReader::new(if let Some(patch_file) = patch_file_opt {
-            Box::new(page_file.chain(patch_file)) as Box<dyn Read>
+            Box::new(page_file.chain(&b"\n"[..]).chain(patch_file)) as Box<dyn Read>
         } else {
             Box::new(page_file) as Box<dyn Read>
         }))
@@ -415,7 +415,7 @@ mod tests {
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
 
-        assert_eq!(&buf, b"Hello\nWorld");
+        assert_eq!(&buf, b"Hello\n\nWorld");
     }
 
     #[test]
@@ -425,7 +425,7 @@ mod tests {
         let page_path = dir.path().join("test.page");
         {
             let mut f = File::create(&page_path).unwrap();
-            f.write_all(b"Hello").unwrap();
+            f.write_all(b"Hello\n").unwrap();
         }
 
         // Create chained reader from lookup result
@@ -436,6 +436,6 @@ mod tests {
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
 
-        assert_eq!(&buf, b"Hello");
+        assert_eq!(&buf, b"Hello\n");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,17 +514,18 @@ fn main() {
         // https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#page-names
         let command = args.command.join("-").to_lowercase();
 
+        // Collect languages
         let languages = args
             .language
             .map_or_else(get_languages_from_env, |lang| vec![lang]);
 
         // Search for command in cache
-        if let Some(page) = cache.find_page(
+        if let Some(lookup_result) = cache.find_page(
             &command,
             &languages,
             config.directories.custom_pages_dir.as_deref(),
         ) {
-            if let Err(msg) = print_page(&page, args.raw, &config) {
+            if let Err(msg) = print_page(&lookup_result, args.raw, &config) {
                 print_error(enable_styles, &msg);
                 process::exit(1);
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,9 +1,6 @@
 //! Functions for printing pages to the terminal
 
-use std::{
-    fs::File,
-    io::{self, BufRead, BufReader, Write},
-};
+use std::io::{self, BufRead, Write};
 
 use crate::{
     cache::PageLookupResult,
@@ -15,41 +12,44 @@ use crate::{
 
 /// Print page by path
 pub fn print_page(
-    page: &PageLookupResult,
+    lookup_result: &PageLookupResult,
     enable_markdown: bool,
     config: &Config,
 ) -> Result<(), String> {
+    // Create reader from file(s)
+    let reader = lookup_result.reader()?;
+
+    // Lock stdout only once, this improves performance considerably
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    for path in page.paths() {
-        let file = File::open(path).map_err(|msg| format!("Could not open file: {}", msg))?;
-        let reader = BufReader::new(file);
-
-        if enable_markdown {
-            // Print the raw markdown of the file.
-            for line in reader.lines() {
-                writeln!(handle, "{}", line.unwrap())
-                    .map_err(|_| "Could not write to stdout".to_string())?;
+    if enable_markdown {
+        // Print the raw markdown of the file.
+        for line in reader.lines() {
+            writeln!(handle, "{}", line.unwrap())
+                .map_err(|_| "Could not write to stdout".to_string())?;
+        }
+    } else {
+        // Closure that processes a page snippet and writes it to stdout
+        let mut process_snippet = |snip: PageSnippet<'_>| {
+            if snip.is_empty() {
+                Ok(())
+            } else {
+                print_snippet(&mut handle, snip, &config.style)
+                    .map_err(|e| WriteError(e.to_string()))
             }
-        } else {
-            let mut process_snippet = |snip: PageSnippet<'_>| {
-                if snip.is_empty() {
-                    Ok(())
-                } else {
-                    print_snippet(&mut handle, snip, &config.style)
-                        .map_err(|e| WriteError(e.to_string()))
-                }
-            };
-            highlight_lines(
-                LineIterator::new(reader),
-                &mut process_snippet,
-                !config.display.compact,
-            )
-            .map_err(|e| format!("Could not write to stdout: {}", e.message()))?;
         };
-    }
 
+        // Print highlighted lines
+        highlight_lines(
+            LineIterator::new(reader),
+            &mut process_snippet,
+            !config.display.compact,
+        )
+        .map_err(|e| format!("Could not write to stdout: {}", e.message()))?;
+    };
+
+    // We're done outputting data, flush stdout now!
     handle
         .flush()
         .map_err(|_| "Could not flush stdout".to_string())?;

--- a/tests/inkscape-v2.patch
+++ b/tests/inkscape-v2.patch
@@ -1,4 +1,3 @@
-
 Custom inkscape entry
 
     My Inkscape example

--- a/tests/inkscape-v2.patch
+++ b/tests/inkscape-v2.patch
@@ -1,5 +1,4 @@
-This header shouldn't be required
-=================================
+
 Custom inkscape entry
 
     My Inkscape example


### PR DESCRIPTION
This way a patch file does not need a well-formed header anymore.

Fixes #181 and thus the last open feature/bug issue for the 1.5.0 milestone! 🎉

Replaces #202.