### PR TITLE
Cache: Return error if HTTP client cannot be created

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -153,7 +153,9 @@ impl Cache {
                 builder = builder.proxy(proxy);
             }
         }
-        let client = builder.build().unwrap_or_else(|_| Client::new());
+        let client = builder.build().map_err(|e| {
+            TealdeerError::UpdateError(format!("Could not instantiate HTTP client: {}", e))
+        })?;
         let mut resp = client.get(&self.url).send()?;
         let mut buf: Vec<u8> = vec![];
         let bytes_downloaded = resp.copy_to(&mut buf)?;


### PR DESCRIPTION
Apparently `Client::new` can panic (see #244), so let's return the error instead.