### PR TITLE
Handle cache download errors

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -150,7 +150,11 @@ impl Cache {
         let client = builder
             .build()
             .context("Could not instantiate HTTP client")?;
-        let mut resp = client.get(&self.url).send()?;
+        let mut resp = client
+            .get(&self.url)
+            .send()?
+            .error_for_status()
+            .with_context(|| format!("Could not download tldr pages from {}", &self.url))?;
         let mut buf: Vec<u8> = vec![];
         let bytes_downloaded = resp.copy_to(&mut buf)?;
         debug!("{} bytes downloaded", bytes_downloaded);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,7 @@ use std::{
     env,
     ffi::OsStr,
     fs::{self, File},
-    io::{BufReader, Cursor, Read, Seek},
+    io::{BufReader, Cursor, Read},
     path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
@@ -157,18 +157,14 @@ impl Cache {
         Ok(buf)
     }
 
-    /// Decompress and open the archive
-    fn decompress<R: Read + Seek>(reader: R) -> ZipArchive<R> {
-        ZipArchive::new(reader).unwrap()
-    }
-
     /// Update the pages cache.
     pub fn update(&self) -> Result<()> {
         // First, download the compressed data
         let bytes: Vec<u8> = self.download()?;
 
         // Decompress the response body into an `Archive`
-        let mut archive = Self::decompress(Cursor::new(bytes));
+        let mut archive = ZipArchive::new(Cursor::new(bytes))
+            .context("Could not decompress downloaded ZIP archive")?;
 
         // Determine paths
         let (cache_dir, _) = Self::get_cache_dir()?;


### PR DESCRIPTION
With this fix, when an invalid ZIP is downloaded:

```
  Error: Could not update cache

  Caused by:
      0: Could not decompress downloaded ZIP archive
      1: invalid Zip archive
```

When a non-successful HTTP error status is returned:

```
  Error: Could not update cache

  Caused by:
      0: Could not download tldr pages from https://tldr.sh/assets/tldr.zap
      1: HTTP status client error (404 Not Found) for url (https://tldr.sh/assets/tldr.zap)
```

Anyhow is awesome 🙂

Fixes #252.