### PR TITLE
Add `no-auto-update` flag

### DIFF
--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -6,7 +6,7 @@ _tealdeer()
 	_init_completion || return
 
 	case $prev in
-		-h|--help|-v|--version|-l|--list|-u|--update|-c|--clear-cache|-p|--pager|-r|--raw|--show-paths|--seed-config|-q|--quiet)
+		-h|--help|-v|--version|-l|--list|-u|--update|--no-auto-update|-c|--clear-cache|-p|--pager|-r|--raw|--show-paths|--seed-config|-q|--quiet)
 			return
 			;;
 		-f|--render)

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -3,19 +3,20 @@
 # https://github.com/dbrgn/tealdeer/
 #
 
-complete -c tldr -s h -l help        -d 'Print the help message.' -f
-complete -c tldr -s v -l version     -d 'Show version information.' -f
-complete -c tldr -s l -l list        -d 'List all commands in the cache.' -f
-complete -c tldr -s f -l render      -d 'Render a specific markdown file.' -r
-complete -c tldr -s p -l platform    -d 'Override the operating system.' -xa 'linux macos sunos windows'
-complete -c tldr -s u -l update      -d 'Update the local cache.' -f
-complete -c tldr -s c -l clear-cache -d 'Clear the local cache.' -f
-complete -c tldr -s p -l pager       -d 'Use a pager to page output.' -f
-complete -c tldr -s r -l raw         -d 'Display the raw markdown instead of rendering it.' -f
-complete -c tldr -s q -l quiet       -d 'Suppress informational messages.' -f
-complete -c tldr      -l show-paths  -d 'Show file and directory paths used by tealdeer.' -f
-complete -c tldr      -l seed-config -d 'Create a basic config.' -f
-complete -c tldr      -l color       -d 'Controls when to use color.' -xa 'always auto never'
+complete -c tldr -s h -l help           -d 'Print the help message.' -f
+complete -c tldr -s v -l version        -d 'Show version information.' -f
+complete -c tldr -s l -l list           -d 'List all commands in the cache.' -f
+complete -c tldr -s f -l render         -d 'Render a specific markdown file.' -r
+complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows'
+complete -c tldr -s u -l update         -d 'Update the local cache.' -f
+complete -c tldr      -l no-auto-update -d 'Disable auto-update, override config file' -f
+complete -c tldr -s c -l clear-cache    -d 'Clear the local cache.' -f
+complete -c tldr -s p -l pager          -d 'Use a pager to page output.' -f
+complete -c tldr -s r -l raw            -d 'Display the raw markdown instead of rendering it.' -f
+complete -c tldr -s q -l quiet          -d 'Suppress informational messages.' -f
+complete -c tldr      -l show-paths     -d 'Show file and directory paths used by tealdeer.' -f
+complete -c tldr      -l seed-config    -d 'Create a basic config.' -f
+complete -c tldr      -l color          -d 'Controls when to use color.' -xa 'always auto never'
 
 function __tealdeer_entries
     tldr --list | string replace -a -i -r "\,\s" "\n"

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -22,6 +22,7 @@ _tealdeer() {
         ))'
         "($I -L --language)"{-L,--language}"[Override the language settings]:lang"
         "($I -u --update)"{-u,--update}"[Update the local cache]"
+        "($I)--no-auto-update[Disable auto-update, override config file]"
         "($I -c --clear-cache)"{-c,--clear-cache}"[Clear the local cache]"
         "($I)--pager[Use a pager to page output]"
         "($I -r --raw)"{-r,--raw}"[Display the raw markdown instead of rendering it]"

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -15,6 +15,7 @@ OPTIONS:
                                  windows, sunos, osx]
     -L, --language <LANGUAGE>    Override the language
     -u, --update                 Update the local cache
+        --no-auto-update         Disable auto-update, override config file
     -c, --clear-cache            Clear the local cache
         --pager                  Use a pager to page output
     -r, --raw                    Display the raw markdown instead of rendering it

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -15,7 +15,7 @@ OPTIONS:
                                  windows, sunos, osx]
     -L, --language <LANGUAGE>    Override the language
     -u, --update                 Update the local cache
-        --no-auto-update         Disable auto-update, override config file
+        --no-auto-update         If auto update is configured, disable it for this run
     -c, --clear-cache            Clear the local cache
         --pager                  Use a pager to page output
     -r, --raw                    Display the raw markdown instead of rendering it

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ pub(crate) struct Args {
     #[clap(short = 'u', long = "update")]
     pub update: bool,
 
-    /// Disable auto-update, override config file
+    /// If auto update is configured, disable it for this run
     #[clap(long = "no-auto-update", requires = "command_or_file")]
     pub no_auto_update: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,10 @@ pub(crate) struct Args {
     #[clap(short = 'u', long = "update")]
     pub update: bool,
 
+    /// Disable auto-update, override config file
+    #[clap(long = "no-auto-update", requires = "command_or_file")]
+    pub no_auto_update: bool,
+
     /// Clear the local cache
     #[clap(short = 'c', long = "clear-cache")]
     pub clear_cache: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,8 @@ const APP_INFO: AppInfo = AppInfo {
 };
 const ARCHIVE_URL: &str = "https://tldr.sh/assets/tldr.zip";
 
-/// The cache should get updated if this was requested by the user, or if auto
-/// updates are enabled and the cache age is longer than the auto update interval,
-/// unless it is explicitly disabled by the user.
+/// The cache should be updated if it was explicitly requested,
+/// or if an automatic update is due and allowed.
 fn should_update_cache(args: &Args, config: &Config) -> bool {
     args.update
         || (!args.no_auto_update

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,12 @@ const APP_INFO: AppInfo = AppInfo {
 const ARCHIVE_URL: &str = "https://tldr.sh/assets/tldr.zip";
 
 /// The cache should get updated if this was requested by the user, or if auto
-/// updates are enabled and the cache age is longer than the auto update interval.
+/// updates are enabled and the cache age is longer than the auto update interval,
+/// unless it is explicitly disabled by the user.
 fn should_update_cache(args: &Args, config: &Config) -> bool {
     args.update
-        || (config.updates.auto_update
+        || (!args.no_auto_update
+            && config.updates.auto_update
             && Cache::last_update().map_or(true, |ago| ago >= config.updates.auto_update_interval))
 }
 


### PR DESCRIPTION
- Adding an empty `rustfmt.toml` enforces default formatter settings regardless of user's global settings
  - See https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#configuring-rustfmt
- Currently if the user enables auto update in the config file, there is no way to temporarily disable it via CLI
  - This is a problem when for example, the network is not available or is very slow. The client simply errors and refuses to display anything, despite the fact that the cache may be perfectly good (albeit a little old)
  - Adding `no-auto-update` flag allows the client to stay usable in such situations

I will need some help with the completion scripts since I have no experience with these.