### PR TITLE
Implement `cache_dir` config file option

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{PathSource, PlatformType},
 };
 
-static CACHE_DIR_ENV_VAR: &str = "TEALDEER_CACHE_DIR";
+pub(crate) static CACHE_DIR_ENV_VAR: &str = "TEALDEER_CACHE_DIR";
 
 pub static TLDR_PAGES_DIR: &str = "tldr-pages";
 static TLDR_OLD_PAGES_DIR: &str = "tldr-master";

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -162,7 +162,7 @@ impl Cache {
     }
 
     /// Download the archive
-    fn download(&self, archive_url: &str) -> Result<Vec<u8>> {
+    fn download(archive_url: &str) -> Result<Vec<u8>> {
         let mut builder = Client::builder();
         if let Ok(ref host) = env::var("HTTP_PROXY") {
             if let Ok(proxy) = Proxy::http(host) {
@@ -191,7 +191,7 @@ impl Cache {
     /// Update the pages cache.
     pub fn update(&self, archive_url: &str) -> Result<()> {
         // First, download the compressed data
-        let bytes: Vec<u8> = self.download(archive_url)?;
+        let bytes: Vec<u8> = Self::download(archive_url)?;
 
         // Decompress the response body into an `Archive`
         let mut archive = ZipArchive::new(Cursor::new(bytes))
@@ -313,7 +313,7 @@ impl Cache {
     }
 
     /// Return the available pages.
-    pub fn list_pages(&self, platform: PlatformType) -> Result<Vec<String>> {
+    pub fn list_pages(&self, platform: PlatformType) -> Vec<String> {
         // FIXME: wait, this doesn't respect language settings?
         let english_pages = self.pages_path.join("pages");
         let platform_dir = Self::platform_directory_name(platform);
@@ -353,7 +353,7 @@ impl Cache {
             .collect::<Vec<String>>();
         pages.sort();
         pages.dedup();
-        Ok(pages)
+        pages
     }
 
     /// Delete the cache directory.

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,12 +164,17 @@ impl Default for RawUpdatesConfig {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct RawDirectoriesConfig {
     #[serde(default)]
+    pub cache_dir: Option<PathBuf>,
+    #[serde(default)]
     pub custom_pages_dir: Option<PathBuf>,
 }
 
 impl Default for RawDirectoriesConfig {
     fn default() -> Self {
         Self {
+            cache_dir: None,
+            // FIXME: should this "business-logic" really be in `*Raw*DirectoriesConfig`?
+            // To me, this seems odd, especially since it can still be `None` afterwards 🤔
             custom_pages_dir: get_app_root(AppDataType::UserData, &crate::APP_INFO)
                 .map(|path| {
                     // Note: The `join("")` call ensures that there's a trailing slash
@@ -238,6 +243,7 @@ pub struct UpdatesConfig {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct DirectoriesConfig {
+    pub cache_dir_override: Option<PathBuf>,
     pub custom_pages_dir: Option<PathBuf>,
 }
 
@@ -270,6 +276,7 @@ impl From<RawConfig> for Config {
                 ),
             },
             directories: DirectoriesConfig {
+                cache_dir_override: raw_config.directories.cache_dir,
                 custom_pages_dir: raw_config.directories.custom_pages_dir,
             },
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ use std::{env, process};
 
 use app_dirs::AppInfo;
 use atty::Stream;
+use cache::CACHE_DIR_ENV_VAR;
 use clap::Parser;
+use types::PathSource;
 
 mod cache;
 mod cli;
@@ -330,10 +332,15 @@ fn main() {
         };
     }
 
-    let (cache_dir, _) = Cache::try_determine_cache_location(&config).unwrap_or_else(|err| {
-        print_error(enable_styles, &err);
-        process::exit(1);
-    });
+    let (cache_dir, cache_dir_source) = Cache::try_determine_cache_location(&config)
+        .unwrap_or_else(|err| {
+            print_error(enable_styles, &err);
+            process::exit(1);
+        });
+    if cache_dir_source == PathSource::EnvVar {
+        print_warning(enable_styles, &format!("You are specifying the location of the pages cache using the DEPRECATED environment variable (${}). Please specify the `cache_dir` in the configuration file instead.", CACHE_DIR_ENV_VAR));
+    }
+
     let cache = Cache::new(ARCHIVE_URL, cache_dir, platform);
 
     // Clear cache, pass through

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,14 +366,7 @@ fn main() {
 
     // List cached commands and exit
     if args.list {
-        // Get list of pages
-        let pages = cache.list_pages(platform).unwrap_or_else(|e| {
-            print_error(enable_styles, &e.context("Could not get list of pages"));
-            process::exit(1);
-        });
-
-        // Print pages
-        println!("{}", pages.join("\n"));
+        println!("{}", cache.list_pages(platform).join("\n"));
         process::exit(0);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn clear_cache(cache: &Cache, quietly: bool, enable_styles: bool) {
 
 /// Update the cache
 fn update_cache(cache: &Cache, quietly: bool, enable_styles: bool) {
-    cache.update().unwrap_or_else(|e| {
+    cache.update(ARCHIVE_URL).unwrap_or_else(|e| {
         print_error(enable_styles, &e.context("Could not update cache"));
         process::exit(1);
     });
@@ -341,7 +341,7 @@ fn main() {
         print_warning(enable_styles, &format!("You are specifying the location of the pages cache using the DEPRECATED environment variable (${}). Please specify the `cache_dir` in the configuration file instead.", CACHE_DIR_ENV_VAR));
     }
 
-    let cache = Cache::new(ARCHIVE_URL, cache_dir, platform);
+    let cache = Cache::new(cache_dir);
 
     // Clear cache, pass through
     if args.clear_cache {
@@ -367,7 +367,7 @@ fn main() {
     // List cached commands and exit
     if args.list {
         // Get list of pages
-        let pages = cache.list_pages().unwrap_or_else(|e| {
+        let pages = cache.list_pages(platform).unwrap_or_else(|e| {
             print_error(enable_styles, &e.context("Could not get list of pages"));
             process::exit(1);
         });
@@ -392,6 +392,7 @@ fn main() {
         // Search for command in cache
         if let Some(lookup_result) = cache.find_page(
             &command,
+            platform,
             &languages,
             config.directories.custom_pages_dir.as_deref(),
         ) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -183,7 +183,6 @@ pub enum PathSource {
     /// Env variable (TEALDEER_*)
     EnvVar,
 
-    #[allow(dead_code)] // Waiting for Pull Request #141
     /// Config file variable
     ConfigVar,
 }


### PR DESCRIPTION
Closes #156, supersedes #212, unless that catches up and gets merged first :)

From the commit message:

> This required that the `Cache` always holds a `PathBuf` with its base
> path and a cached `PathBuf` of the pages directory. This implies that
> some cache operations (such as clearing) are now instance methods
> instead of class methods, because the instance variables are used
> (we always re-resolved the paths before).
> 
> On the way, I stumbled upon some oddities and added `FIXME`s. Please let
> me know what you think about them :)

TODO
- [x] deprecate env var
- [ ] ~~`paths` module?~~ another time