### PR TITLE
Add support for android platform

### DIFF
--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -14,7 +14,7 @@ _tealdeer()
 			return
 			;;
 		-p|--platform)
-			COMPREPLY=( $(compgen -W 'linux macos sunos windows' -- "${cur}") )
+			COMPREPLY=( $(compgen -W 'linux macos sunos windows android' -- "${cur}") )
 			return
 			;;
 		--color)

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -7,7 +7,7 @@ complete -c tldr -s h -l help           -d 'Print the help message.' -f
 complete -c tldr -s v -l version        -d 'Show version information.' -f
 complete -c tldr -s l -l list           -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render         -d 'Render a specific markdown file.' -r
-complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows'
+complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows android'
 complete -c tldr -s u -l update         -d 'Update the local cache.' -f
 complete -c tldr      -l no-auto-update -d 'If auto update is configured, disable it for this run.' -f
 complete -c tldr -s c -l clear-cache    -d 'Clear the local cache.' -f

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -19,6 +19,7 @@ _tealdeer() {
             macos
             sunos
             windows
+            android
         ))'
         "($I -L --language)"{-L,--language}"[Override the language settings]:lang"
         "($I -u --update)"{-u,--update}"[Update the local cache]"

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -12,7 +12,7 @@ OPTIONS:
     -l, --list                   List all commands in the cache
     -f, --render <FILE>          Render a specific markdown file
     -p, --platform <PLATFORM>    Override the operating system [possible values: linux, macos,
-                                 windows, sunos, osx]
+                                 windows, sunos, osx, android]
     -L, --language <LANGUAGE>    Override the language
     -u, --update                 Update the local cache
         --no-auto-update         If auto update is configured, disable it for this run

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -223,6 +223,7 @@ impl Cache {
             PlatformType::OsX => "osx",
             PlatformType::SunOs => "sunos",
             PlatformType::Windows => "windows",
+            PlatformType::Android => "android",
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,7 +39,7 @@ pub(crate) struct Args {
     #[clap(
         short = 'p',
         long = "platform",
-        possible_values = ["linux", "macos", "windows", "sunos", "osx"],
+        possible_values = ["linux", "macos", "windows", "sunos", "osx", "android"],
     )]
     pub platform: Option<PlatformType>,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,6 +68,11 @@ impl PlatformType {
         Self::Windows
     }
 
+    #[cfg(target_os = "android")]
+    pub fn current() -> Self {
+        Self::Android
+    }
+
     #[cfg(not(any(
         target_os = "linux",
         target_os = "macos",
@@ -75,7 +80,8 @@ impl PlatformType {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "dragonfly",
-        target_os = "windows"
+        target_os = "windows",
+        target_os = "android",
     )))]
     pub fn current() -> Self {
         Self::Other

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,7 @@ pub enum PlatformType {
     OsX,
     SunOs,
     Windows,
+    Android,
 }
 
 impl fmt::Display for PlatformType {
@@ -22,6 +23,7 @@ impl fmt::Display for PlatformType {
             Self::OsX => write!(f, "macOS / BSD"),
             Self::SunOs => write!(f, "SunOS"),
             Self::Windows => write!(f, "Windows"),
+            Self::Android => write!(f, "Android"),
         }
     }
 }
@@ -35,8 +37,9 @@ impl str::FromStr for PlatformType {
             "osx" | "macos" => Ok(Self::OsX),
             "sunos" => Ok(Self::SunOs),
             "windows" => Ok(Self::Windows),
+            "android" => Ok(Self::Android),
             other => Err(anyhow!(
-                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows",
+                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows, android",
                 other
             )),
         }


### PR DESCRIPTION
`tldr` added android-specific commands under a new 'android' platform last year: <https://github.com/tldr-pages/tldr/issues/5462>

I think I caught all uses of the platform types, but another pair of eyes would be much appreciated!