### PR TITLE
Allow overriding cache directory through config

### DIFF
--- a/docs/src/config_directories.md
+++ b/docs/src/config_directories.md
@@ -2,6 +2,19 @@
 
 This section allows overriding some directory paths.
 
+## `cache_dir`
+
+Override the cache directory. Remember to use an absolute path. Variable
+expansion will not be performed on the path. If the directory does not yet
+exist, it will be created.
+
+    [directories]
+    cache_dir = "/home/myuser/.tealdeer-cache/"
+
+If no `cache_dir` is specified, tealdeer will fall back to a location that
+follows OS conventions. On Linux, it will usually be at `~/.cache/tealdeer/`.
+Use `tldr --show-paths` to show the path that is being used.
+
 ## `custom_pages_dir`
 
 Set the directory to be used to look up [custom

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,15 +8,12 @@ use std::{
 };
 
 use anyhow::{ensure, Context, Result};
-use app_dirs::{get_app_root, AppDataType};
 use log::debug;
 use reqwest::{blocking::Client, Proxy};
 use walkdir::{DirEntry, WalkDir};
 use zip::ZipArchive;
 
-use crate::types::{PathSource, PlatformType};
-
-static CACHE_DIR_ENV_VAR: &str = "TEALDEER_CACHE_DIR";
+use crate::types::PlatformType;
 
 pub static TLDR_PAGES_DIR: &str = "tldr-pages";
 static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
@@ -25,6 +22,7 @@ static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
 pub struct Cache {
     url: String,
     platform: PlatformType,
+    cache_dir: PathBuf,
 }
 
 #[derive(Debug)]
@@ -54,13 +52,13 @@ impl PageLookupResult {
     pub fn reader(&self) -> Result<BufReader<Box<dyn Read>>> {
         // Open page file
         let page_file = File::open(&self.page_path)
-            .with_context(|| format!("Could not open page file at {:?}", self.page_path))?;
+            .with_context(|| format!("Could not open page file at {}", self.page_path.display()))?;
 
         // Open patch file
         let patch_file_opt = match &self.patch_path {
             Some(path) => Some(
                 File::open(path)
-                    .with_context(|| format!("Could not open patch file at {:?}", path))?,
+                    .with_context(|| format!("Could not open patch file at {}", path.display()))?,
             ),
             None => None,
         };
@@ -89,49 +87,42 @@ pub enum CacheFreshness {
 }
 
 impl Cache {
-    pub fn new<S>(url: S, platform: PlatformType) -> Self
+    pub fn new<S, P>(url: S, platform: PlatformType, cache_dir: P) -> Result<Self>
     where
         S: Into<String>,
+        P: Into<PathBuf>,
     {
-        Self {
+        // Check whether `cache_dir` exists and is a directory
+        let cache_dir = cache_dir.into();
+        let (cache_dir_exists, cache_dir_is_dir) = cache_dir
+            .metadata()
+            .map_or((false, false), |md| (true, md.is_dir()));
+        ensure!(
+            !cache_dir_exists || cache_dir_is_dir,
+            "Cache directory path `{}` is not a directory",
+            cache_dir.display(),
+        );
+
+        // If necessary, create cache directory
+        if !cache_dir_exists {
+            // Try to create the complete directory path
+            fs::create_dir_all(&cache_dir).with_context(|| {
+                format!(
+                    "Cache directory path `{}` cannot be created",
+                    cache_dir.display(),
+                )
+            })?;
+            eprintln!(
+                "Successfully created cache directory path `{}`.",
+                cache_dir.display(),
+            );
+        }
+
+        Ok(Self {
             url: url.into(),
             platform,
-        }
-    }
-
-    /// Return the path to the cache directory.
-    pub fn get_cache_dir() -> Result<(PathBuf, PathSource)> {
-        // Allow overriding the cache directory by setting the env variable.
-        if let Ok(value) = env::var(CACHE_DIR_ENV_VAR) {
-            let path = PathBuf::from(value);
-            let (path_exists, path_is_dir) = path
-                .metadata()
-                .map_or((false, false), |md| (true, md.is_dir()));
-            ensure!(
-                !path_exists || path_is_dir,
-                "Path specified by ${} is not a directory",
-                CACHE_DIR_ENV_VAR
-            );
-            if !path_exists {
-                // Try to create the complete directory path.
-                fs::create_dir_all(&path).with_context(|| {
-                    format!(
-                        "Directory path specified by ${} cannot be created",
-                        CACHE_DIR_ENV_VAR
-                    )
-                })?;
-                eprintln!(
-                    "Successfully created cache directory path `{}`.",
-                    path.to_str().unwrap()
-                );
-            }
-            return Ok((path, PathSource::EnvVar));
-        };
-
-        // Otherwise, fall back to user cache directory.
-        let dirs = get_app_root(AppDataType::UserCache, &crate::APP_INFO)
-            .context("Could not determine user cache directory")?;
-        Ok((dirs, PathSource::OsConvention))
+            cache_dir,
+        })
     }
 
     /// Download the archive
@@ -171,12 +162,7 @@ impl Cache {
             .context("Could not decompress downloaded ZIP archive")?;
 
         // Determine paths
-        let (cache_dir, _) = Self::get_cache_dir()?;
-        let pages_dir = cache_dir.join(TLDR_PAGES_DIR);
-
-        // Make sure that cache directory exists
-        debug!("Ensure cache directory {:?} exists", &cache_dir);
-        fs::create_dir_all(&cache_dir).context("Could not create cache directory")?;
+        let pages_dir = self.cache_dir.join(TLDR_PAGES_DIR);
 
         // Clear cache directory
         // Note: This is not the best solution. Ideally we would download the
@@ -184,7 +170,8 @@ impl Cache {
         // But renaming a directory doesn't work across filesystems and Rust
         // does not yet offer a recursive directory copying function. So for
         // now, we'll use this approach.
-        Self::clear().context("Could not clear the cache directory")?;
+        self.clear()
+            .context("Could not clear the cache directory")?;
 
         // Extract archive
         archive
@@ -195,21 +182,19 @@ impl Cache {
     }
 
     /// Return the duration since the cache directory was last modified.
-    pub fn last_update() -> Option<Duration> {
-        if let Ok((cache_dir, _)) = Self::get_cache_dir() {
-            if let Ok(metadata) = fs::metadata(cache_dir.join(TLDR_PAGES_DIR)) {
-                if let Ok(mtime) = metadata.modified() {
-                    let now = SystemTime::now();
-                    return now.duration_since(mtime).ok();
-                };
+    pub fn last_update(&self) -> Option<Duration> {
+        if let Ok(metadata) = fs::metadata(self.cache_dir.join(TLDR_PAGES_DIR)) {
+            if let Ok(mtime) = metadata.modified() {
+                let now = SystemTime::now();
+                return now.duration_since(mtime).ok();
             };
         };
         None
     }
 
     /// Return the freshness of the cache (fresh, stale or missing).
-    pub fn freshness() -> CacheFreshness {
-        match Cache::last_update() {
+    pub fn freshness(&self) -> CacheFreshness {
+        match self.last_update() {
             Some(ago) if ago > crate::config::MAX_CACHE_AGE => CacheFreshness::Stale(ago),
             Some(_) => CacheFreshness::Fresh,
             None => CacheFreshness::Missing,
@@ -258,15 +243,8 @@ impl Cache {
         let patch_filename = format!("{}.patch", name);
         let custom_filename = format!("{}.page", name);
 
-        // Get cache dir
-        let cache_dir = match Self::get_cache_dir() {
-            Ok((cache_dir, _)) => cache_dir.join(TLDR_PAGES_DIR),
-            Err(e) => {
-                log::error!("Could not get cache directory: {}", e);
-                return None;
-            }
-        };
-
+        // Determine directories
+        let cache_dir = self.cache_dir.join(TLDR_PAGES_DIR);
         let lang_dirs: Vec<String> = languages
             .iter()
             .map(|lang| {
@@ -302,10 +280,9 @@ impl Cache {
     }
 
     /// Return the available pages.
-    pub fn list_pages(&self, custom_pages_dir: Option<&Path>) -> Result<Vec<String>> {
+    pub fn list_pages(&self, custom_pages_dir: Option<&Path>) -> Vec<String> {
         // Determine platforms directory and platform
-        let (cache_dir, _) = Self::get_cache_dir()?;
-        let platforms_dir = cache_dir.join(TLDR_PAGES_DIR).join("pages");
+        let platforms_dir = self.cache_dir.join(TLDR_PAGES_DIR).join("pages");
         let platform_dir = self.get_platform_dir();
 
         // Closure that allows the WalkDir instance to traverse platform
@@ -367,29 +344,27 @@ impl Cache {
 
         pages.sort();
         pages.dedup();
-        Ok(pages)
+        pages
     }
 
     /// Delete the cache directory.
-    pub fn clear() -> Result<()> {
-        let (path, _) = Self::get_cache_dir()?;
-
+    pub fn clear(&self) -> Result<()> {
         // Check preconditions
         ensure!(
-            path.exists(),
+            self.cache_dir.exists(),
             "Cache path ({}) does not exist.",
-            path.display(),
+            self.cache_dir.display(),
         );
         ensure!(
-            path.is_dir(),
+            self.cache_dir.is_dir(),
             "Cache path ({}) is not a directory.",
-            path.display()
+            self.cache_dir.display(),
         );
 
         // Delete old tldr-pages cache location as well if present
         // TODO: To be removed in the future
         for pages_dir_name in [TLDR_PAGES_DIR, TLDR_OLD_PAGES_DIR] {
-            let pages_dir = path.join(pages_dir_name);
+            let pages_dir = self.cache_dir.join(pages_dir_name);
 
             if pages_dir.exists() {
                 fs::remove_dir_all(&pages_dir).with_context(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,9 +161,13 @@ fn show_paths(config: &Config) {
         |e| format!("[Error: {}]", e),
         |(path, _)| path.display().to_string(),
     );
-    let cache_dir = config.directories.cache_dir.display();
+    let cache_dir = format!(
+        "{} ({})",
+        config.directories.cache_dir.path.display(),
+        config.directories.cache_dir.source
+    );
     let pages_dir = {
-        let mut path = config.directories.cache_dir.clone();
+        let mut path = config.directories.cache_dir.path.clone();
         path.push(TLDR_PAGES_DIR);
         path.push(""); // Trailing path separator
         path.display().to_string()
@@ -328,8 +332,8 @@ fn main() {
     }
 
     // Initialize cache
-    let cache =
-        Cache::new(ARCHIVE_URL, platform, &config.directories.cache_dir).unwrap_or_else(|e| {
+    let cache = Cache::new(ARCHIVE_URL, platform, &config.directories.cache_dir.path)
+        .unwrap_or_else(|e| {
             print_error(enable_styles, &e.context("Could not initialize cache"));
             process::exit(1);
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn clear_cache(cache: &Cache, quietly: bool, enable_styles: bool) {
 
 /// Update the cache
 fn update_cache(cache: &Cache, quietly: bool, enable_styles: bool) {
-    cache.update().unwrap_or_else(|e| {
+    cache.update(ARCHIVE_URL).unwrap_or_else(|e| {
         print_error(enable_styles, &e.context("Could not update cache"));
         process::exit(1);
     });
@@ -325,11 +325,10 @@ fn main() {
     }
 
     // Initialize cache
-    let cache = Cache::new(ARCHIVE_URL, platform, &config.directories.cache_dir.path)
-        .unwrap_or_else(|e| {
-            print_error(enable_styles, &e.context("Could not initialize cache"));
-            process::exit(1);
-        });
+    let cache = Cache::new(platform, &config.directories.cache_dir.path).unwrap_or_else(|e| {
+        print_error(enable_styles, &e.context("Could not initialize cache"));
+        process::exit(1);
+    });
 
     // Clear cache, pass through
     if args.clear_cache {

--- a/src/types.rs
+++ b/src/types.rs
@@ -185,16 +185,14 @@ impl LineType {
 }
 
 /// The reason why a certain path (e.g. config path or cache dir) was chosen.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum PathSource {
     /// OS convention (e.g. XDG on Linux)
     OsConvention,
     /// Env variable (TEALDEER_*)
     EnvVar,
-
-    #[allow(dead_code)] // Waiting for Pull Request #141
-    /// Config file variable
-    ConfigVar,
+    /// Config file
+    ConfigFile,
 }
 
 impl fmt::Display for PathSource {
@@ -205,7 +203,7 @@ impl fmt::Display for PathSource {
             match self {
                 Self::OsConvention => "OS convention",
                 Self::EnvVar => "env variable",
-                Self::ConfigVar => "config file variable",
+                Self::ConfigFile => "config file",
             }
         )
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -263,9 +263,12 @@ fn test_cache_location_not_a_directory() {
         .assert()
         .failure()
         .stderr(contains(format!(
-            "Path specified by ${} is not a directory",
-            CACHE_DIR_ENV_VAR
-        )));
+            "Cache directory path `{}` is not a directory",
+            internal_file.display(),
+        )))
+        .stderr(contains(
+            "Warning: The $TEALDEER_CACHE_DIR env variable is deprecated",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
Based on #212. Thanks @hgaiser for the initial work!

- Config: Add `cache_dir` to `[directories]` section
- Deprecate old `TEALDEER_CACHE_DIR` env variable
- Introduce path source for `custom_pages_dir` as well
- Add integration test
- Update docs

Implementation notes:

- Logic to handle legacy env var, config override and default cache dir selection is now in the `Config::try_from(RawConfig)` impl
- Logic to determine `custom_pages_dir` is moved into `Config::try_from(RawConfig)` as well for consistency

The logic to determine which cache directory is used is now in `config.rs`, when converting the `RawConfig` to `Config`. I think this is the place where the config file and external factors (defaults, env vars, etc) can be taken into account to determine a final config.