### PR TITLE
added missing fish completion for language

### DIFF
--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -8,6 +8,7 @@ complete -c tldr -s v -l version        -d 'Show version information.' -f
 complete -c tldr -s l -l list           -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render         -d 'Render a specific markdown file.' -r
 complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows android'
+complete -c tldr -s L -l language       -d 'Override the language' -x
 complete -c tldr -s u -l update         -d 'Update the local cache.' -f
 complete -c tldr      -l no-auto-update -d 'If auto update is configured, disable it for this run.' -f
 complete -c tldr -s c -l clear-cache    -d 'Clear the local cache.' -f


### PR DESCRIPTION
I tried to use this project and noticed that not all flags have tab completion for fish, so I added the missing one for `--language`.
The one for `--config-path` is missing, too, but since the flag is deprecated, it shouldn't be included anyway.