### PR TITLE
Add custom pages to list output

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -324,6 +324,14 @@ impl Cache {
             false
         };
 
+        let to_stem = |entry: DirEntry| -> Option<String> {
+            entry
+                .path()
+                .file_stem()
+                .and_then(OsStr::to_str)
+                .map(str::to_string)
+        };
+
         // Recursively walk through common and (if applicable) platform specific directory
         let mut pages = WalkDir::new(platforms_dir)
             .min_depth(1) // Skip root directory
@@ -331,11 +339,9 @@ impl Cache {
             .filter_entry(should_walk) // Filter out pages for other architectures
             .filter_map(Result::ok) // Convert results to options, filter out errors
             .filter_map(|e| {
-                let path = e.path();
-                let extension = &path.extension().and_then(OsStr::to_str).unwrap_or("");
-                if e.file_type().is_file() && extension == &"md" {
-                    path.file_stem()
-                        .and_then(|stem| stem.to_str().map(Into::into))
+                let extension = e.path().extension().unwrap_or_default();
+                if e.file_type().is_file() && extension == "md" {
+                    to_stem(e)
                 } else {
                     None
                 }
@@ -344,26 +350,19 @@ impl Cache {
 
         if let Some(custom_pages_dir) = custom_pages_dir {
             let is_page = |entry: &DirEntry| -> bool {
-                let path = entry.path();
-                let extension = &path.extension().and_then(OsStr::to_str).unwrap_or("");
-                entry.file_type().is_file() && extension == &"page"
+                let extension = entry.path().extension().unwrap_or_default();
+                entry.file_type().is_file() && extension == "page"
             };
-            let to_stem = |entry: DirEntry| -> Option<String> {
-                entry
-                    .path()
-                    .file_stem()
-                    .and_then(|stem| stem.to_str().map(Into::into))
-            };
-            let mut custom_pages = WalkDir::new(custom_pages_dir)
+
+            let custom_pages = WalkDir::new(custom_pages_dir)
                 .min_depth(1)
                 .max_depth(1)
                 .into_iter()
                 .filter_entry(is_page)
                 .filter_map(Result::ok)
-                .filter_map(to_stem)
-                .collect::<Vec<String>>();
+                .filter_map(to_stem);
 
-            pages.append(&mut custom_pages);
+            pages.extend(custom_pages);
         }
 
         pages.sort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,10 +365,12 @@ fn main() {
     // List cached commands and exit
     if args.list {
         // Get list of pages
-        let pages = cache.list_pages().unwrap_or_else(|e| {
-            print_error(enable_styles, &e.context("Could not get list of pages"));
-            process::exit(1);
-        });
+        let pages = cache
+            .list_pages(config.directories.custom_pages_dir.as_deref())
+            .unwrap_or_else(|e| {
+                print_error(enable_styles, &e.context("Could not get list of pages"));
+                process::exit(1);
+            });
 
         // Print pages
         println!("{}", pages.join("\n"));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -513,6 +513,12 @@ fn test_pager_flag_enable() {
 fn test_list_flag_rendering() {
     let testenv = TestEnv::new();
 
+    // set custom pages directory
+    testenv.write_config(format!(
+        "[directories]\ncustom_pages_dir = '{}'",
+        testenv.custom_pages_dir.path().to_str().unwrap()
+    ));
+
     testenv
         .command()
         .args(["--list"])
@@ -532,13 +538,17 @@ fn test_list_flag_rendering() {
     testenv.add_entry("bar", "");
     testenv.add_entry("baz", "");
     testenv.add_entry("qux", "");
+    testenv.add_page_entry("faz", "");
+    testenv.add_page_entry("bar", "");
+    testenv.add_page_entry("fiz", "");
+    testenv.add_patch_entry("buz", "");
 
     testenv
         .command()
         .args(["--list"])
         .assert()
         .success()
-        .stdout("bar\nbaz\nfoo\nqux\n");
+        .stdout("bar\nbaz\nfaz\nfiz\nfoo\nqux\n");
 }
 
 #[test]


### PR DESCRIPTION
Fix #205 

I have added custom pages to the output of list by reading from the `custom_pages_dir` from the config and walking that directory for any pages. This also includes custom pages in the autocompletion.

This is my first contribution, so please let me know if something has to be changed or added :innocent: 