### PR TITLE
Add a `--edit` option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,6 +85,15 @@ pub(crate) struct Args {
     )]
     pub markdown: bool,
 
+    /// Open file on Github for editing
+    #[clap(
+        long = "edit",
+        short = 'e',
+        requires = "command",
+        conflicts_with = "raw"
+    )]
+    pub edit: bool,
+
     /// Suppress informational messages
     #[clap(short = 'q', long = "quiet")]
     pub quiet: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ use crate::{
     cli::Args,
     config::{get_config_dir, get_config_path, make_default_config, Config},
     extensions::Dedup,
-    output::print_page,
+    output::{open_browser, print_page},
     types::{ColorOptions, PlatformType},
     utils::{print_error, print_warning},
 };
@@ -393,6 +393,14 @@ fn main() {
             &languages,
             config.directories.custom_pages_dir.as_deref(),
         ) {
+            if args.edit {
+                let full_path = lookup_result.page_path.to_string_lossy();
+                if let Err(ref e) = open_browser(&full_path) {
+                    print_error(enable_styles, e);
+                    process::exit(1);
+                }
+                process::exit(0);
+            }
             if let Err(ref e) =
                 print_page(&lookup_result, args.raw, enable_styles, args.pager, &config)
             {


### PR DESCRIPTION
This option will help contributing, as the _edit this page on github_ button does on https://tldr.ostera.io/man.

This is a minimum viable product. If you feel this is interesting, I could go further and open an editor if the page is a local page or if it contains a patch. To do so, I was thinking of refactoring a tiny bit `PageLookupResult` to contain those information.