### PR TITLE
Replace ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,7 +1102,6 @@ dependencies = [
 name = "tealdeer"
 version = "1.5.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "app_dirs2",
  "assert_cmd",
@@ -1129,6 +1119,7 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
+ "yansi",
  "zip",
 ]
 
@@ -1552,6 +1543,12 @@ checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
 dependencies = [
  "dirs",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ name = "tldr"
 path = "src/main.rs"
 
 [dependencies]
-ansi_term = "0.12.0"
 anyhow = "1"
 app_dirs = { version = "2", package = "app_dirs2" }
 atty = "0.2"
@@ -32,6 +31,7 @@ serde = "1.0.21"
 serde_derive = "1.0.21"
 toml = "0.5.1"
 walkdir = "2.0.1"
+yansi = "0.5"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/docs/src/config_style.md
+++ b/docs/src/config_style.md
@@ -22,7 +22,7 @@ Using the config file, the style (e.g. colors or underlines) can be customized.
 
 Colors can be specified in one of three ways:
 
-- Color string (`black`, `red`, `green`, `yellow`, `blue`, `purple`, `cyan`, `white`):
+- Color string (`black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`):
 
   Example:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,11 +5,11 @@ use std::{
     time::Duration,
 };
 
-use ansi_term::{Color, Style};
 use anyhow::{ensure, Context, Result};
 use app_dirs::{get_app_root, AppDataType};
 use log::debug;
 use serde_derive::{Deserialize, Serialize};
+use yansi::{Color, Style};
 
 use crate::types::PathSource;
 
@@ -37,7 +37,8 @@ pub enum RawColor {
     Green,
     Yellow,
     Blue,
-    Purple,
+    Magenta,
+    Purple, // Backwards compatibility with ansi_term (until tealdeer 1.5.0)
     Cyan,
     White,
     Ansi(u8),
@@ -52,7 +53,7 @@ impl From<RawColor> for Color {
             RawColor::Green => Self::Green,
             RawColor::Yellow => Self::Yellow,
             RawColor::Blue => Self::Blue,
-            RawColor::Purple => Self::Purple,
+            RawColor::Magenta | RawColor::Purple => Self::Magenta,
             RawColor::Cyan => Self::Cyan,
             RawColor::White => Self::White,
             RawColor::Ansi(num) => Self::Fixed(num),
@@ -95,7 +96,7 @@ impl From<RawStyle> for Style {
         }
 
         if let Some(background) = raw_style.background {
-            style = style.on(Color::from(background));
+            style = style.bg(Color::from(background));
         }
 
         if raw_style.underline {
@@ -215,7 +216,7 @@ impl Default for RawConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StyleConfig {
     pub description: Style,
     pub command_name: Style,
@@ -241,7 +242,7 @@ pub struct DirectoriesConfig {
     pub custom_pages_dir: Option<PathBuf>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Config {
     pub style: StyleConfig,
     pub display: DisplayConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn main() {
 
     // Determine the usage of styles
     #[cfg(target_os = "windows")]
-    let ansi_support = ansi_term::enable_ansi_support().is_ok();
+    let ansi_support = yansi::Paint::enable_windows_ascii();
     #[cfg(not(target_os = "windows"))]
     let ansi_support = true;
     let enable_styles = match args.color.unwrap_or_default() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use ansi_term::{Color, Style};
+use yansi::Color;
 
 /// Print a warning to stderr. If `enable_styles` is true, then a yellow
 /// message will be printed.
@@ -19,8 +19,7 @@ pub fn print_error(enable_styles: bool, error: &anyhow::Error) {
 
 fn print_msg(enable_styles: bool, message: &str, prefix: &'static str, color: Color) {
     if enable_styles {
-        let style = Style::new().fg(color);
-        eprintln!("{}{}", style.paint(prefix), style.paint(message));
+        eprintln!("{}{}", color.paint(prefix), color.paint(message));
     } else {
         eprintln!("{}", message);
     }


### PR DESCRIPTION
ansi_term is not actively maintained anymore (see https://rustsec.org/advisories/RUSTSEC-2021-0139). Replace it with a suitable alternative.

I looked at termcolor, owo-colors and yansi, and ended up picking yansi:

- It is very simple
- It does not do terminal color support checking (we already do that in tealdeer)
- Its color enum type is almost identical to the one from ansi_term, so migrating is easy
- It's developed by Sergio Benitez (of Rocket fame)

The only change from a config API point of view is that "purple" is now renamed to "magenta", but "purple" still works.

(Based on #287, merge that one first!)