### PR TITLE
Remove deprecated commands

### DIFF
--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -21,7 +21,6 @@ OPTIONS:
     -r, --raw                    Display the raw markdown instead of rendering it
     -q, --quiet                  Suppress informational messages
         --show-paths             Show file and directory paths used by tealdeer
-        --config-path            Show config file path
         --seed-config            Create a basic config
         --color <WHEN>           Control whether to use color [possible values: always, auto, never]
     -v, --version                Print the version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,15 +43,6 @@ pub(crate) struct Args {
     )]
     pub platform: Option<PlatformType>,
 
-    /// Deprecated alias of `platform`
-    #[clap(
-        short = 'o',
-        long = "os",
-        possible_values = ["linux", "macos", "windows", "sunos", "osx"],
-        hide = true
-    )]
-    pub os: Option<PlatformType>,
-
     /// Override the language
     #[clap(short = 'L', long = "language")]
     pub language: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,10 +93,6 @@ pub(crate) struct Args {
     #[clap(long = "show-paths")]
     pub show_paths: bool,
 
-    /// Show config file path
-    #[clap(long = "config-path")]
-    pub config_path: bool,
-
     /// Create a basic config
     #[clap(long = "seed-config")]
     pub seed_config: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,15 +67,6 @@ pub(crate) struct Args {
     #[clap(short = 'r', long = "--raw", requires = "command_or_file")]
     pub raw: bool,
 
-    /// Deprecated alias of `raw`
-    #[clap(
-        long = "markdown",
-        short = 'm',
-        requires = "command_or_file",
-        hide = true
-    )]
-    pub markdown: bool,
-
     /// Suppress informational messages
     #[clap(short = 'q', long = "quiet")]
     pub quiet: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,7 @@ fn main() {
     init_log();
 
     // Parse arguments
-    let mut args = Args::parse();
+    let args = Args::parse();
 
     // Determine the usage of styles
     #[cfg(target_os = "windows")]
@@ -260,15 +260,6 @@ fn main() {
         // Disable styling
         ColorOptions::Never => false,
     };
-
-    // Handle renamed arguments
-    if args.markdown {
-        args.raw = true;
-        print_warning(
-            enable_styles,
-            "The -m / --markdown flag is deprecated, use -r / --raw instead",
-        );
-    }
 
     // Look up config file, if none is found fall back to default config.
     let config = match Config::load(enable_styles) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,13 +269,6 @@ fn main() {
             "The -m / --markdown flag is deprecated, use -r / --raw instead",
         );
     }
-    if args.os.is_some() {
-        print_warning(
-            enable_styles,
-            "The -o / --os flag is deprecated, use -p / --platform instead",
-        );
-    }
-    args.platform = args.platform.or(args.os);
 
     // Look up config file, if none is found fall back to default config.
     let config = match Config::load(enable_styles) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,19 +140,6 @@ fn update_cache(cache: &Cache, quietly: bool, enable_styles: bool) {
     }
 }
 
-/// Show the config path (DEPRECATED)
-fn show_config_path(enable_styles: bool) {
-    match get_config_path() {
-        Ok((config_file_path, _)) => {
-            println!("Config path is: {}", config_file_path.to_str().unwrap());
-        }
-        Err(e) => {
-            print_error(enable_styles, &e.context("Could not look up config path"));
-            process::exit(1);
-        }
-    }
-}
-
 /// Show file paths
 fn show_paths(config: &Config) {
     let config_dir = get_config_dir().map_or_else(
@@ -289,15 +276,6 @@ fn main() {
         );
     }
     args.platform = args.platform.or(args.os);
-
-    // Show config file and path, pass through
-    if args.config_path {
-        print_warning(
-            enable_styles,
-            "The --config-path flag is deprecated, use --show-paths instead",
-        );
-        show_config_path(enable_styles);
-    }
 
     // Look up config file, if none is found fall back to default config.
     let config = match Config::load(enable_styles) {


### PR DESCRIPTION
Three commands were deprecated in the last release of tealdeer (1.5.0, almost a year ago) and can be removed now:

- `--config-path` (use `--show-paths` instead)
- `-o / --os` (use `-p/--platform` instead)
- `-m / --markdown` (use `-r/--raw` instead)