### PR TITLE
Add auto generate completions for some shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1115,7 @@ dependencies = [
  "assert_cmd",
  "atty",
  "clap",
+ "clap_complete",
  "env_logger",
  "escargot",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = "1"
 app_dirs = { version = "2", package = "app_dirs2" }
 atty = "0.2"
 clap = { version = "3", features = ["std", "derive", "suggestions", "color"], default-features = false }
+clap_complete = "3"
 env_logger = { version = "0.9", optional = true }
 log = "0.4"
 reqwest = { version = "0.11.3", features = ["blocking"], default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ mod utils;
 
 use crate::{
     cache::{Cache, CacheFreshness, PageLookupResult, TLDR_PAGES_DIR},
-    cli::Args,
+    cli::{Args, Generate},
     config::{get_config_dir, get_config_path, make_default_config, Config, PathWithSource},
     extensions::Dedup,
     output::print_page,
@@ -270,6 +270,15 @@ fn main() {
         }
     };
 
+    let mut has_generator = false;
+    // Generate completions
+    if let Some(generator) = &args.generator {
+        let Generate::Completion { shell, path: _ } = generator;
+        eprintln!("Generating completion file for {:?}...", shell);
+        generator.generate();
+        has_generator = true;
+    }
+
     // Show various paths
     if args.show_paths {
         show_paths(&config);
@@ -303,7 +312,7 @@ fn main() {
     }
 
     // Cache update, pass through
-    let cache_updated = if should_update_cache(&cache, &args, &config) {
+    let cache_updated = if should_update_cache(&cache, &args, &config) || has_generator {
         update_cache(&cache, args.quiet, enable_styles);
         true
     } else {


### PR DESCRIPTION
This is a requested function that solves problem #268 by generating automatic autocompletions and allows updating the cache

- [x] Check format
- [x] Check clippy
- [x] test commands implementation

### Supported Shells
- Bash
- Zsh
- Fish
- Powershell
- Elvish