### PR TITLE
Allow querying multiple platforms

### DIFF
--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -9,21 +9,22 @@ ARGS:
     <COMMAND>...    The command to show (e.g. `tar` or `git log`)
 
 OPTIONS:
-    -l, --list                   List all commands in the cache
-    -f, --render <FILE>          Render a specific markdown file
-    -p, --platform <PLATFORM>    Override the operating system [possible values: linux, macos,
-                                 windows, sunos, osx, android]
-    -L, --language <LANGUAGE>    Override the language
-    -u, --update                 Update the local cache
-        --no-auto-update         If auto update is configured, disable it for this run
-    -c, --clear-cache            Clear the local cache
-        --pager                  Use a pager to page output
-    -r, --raw                    Display the raw markdown instead of rendering it
-    -q, --quiet                  Suppress informational messages
-        --show-paths             Show file and directory paths used by tealdeer
-        --seed-config            Create a basic config
-        --color <WHEN>           Control whether to use color [possible values: always, auto, never]
-    -v, --version                Print the version
-    -h, --help                   Print help information
+    -l, --list                    List all commands in the cache
+    -f, --render <FILE>           Render a specific markdown file
+    -p, --platform <PLATFORMS>    Override the operating system [possible values: linux, macos,
+                                  windows, sunos, osx, android]
+    -L, --language <LANGUAGE>     Override the language
+    -u, --update                  Update the local cache
+        --no-auto-update          If auto update is configured, disable it for this run
+    -c, --clear-cache             Clear the local cache
+        --pager                   Use a pager to page output
+    -r, --raw                     Display the raw markdown instead of rendering it
+    -q, --quiet                   Suppress informational messages
+        --show-paths              Show file and directory paths used by tealdeer
+        --seed-config             Create a basic config
+        --color <WHEN>            Control whether to use color [possible values: always, auto,
+                                  never]
+    -v, --version                 Print the version
+    -h, --help                    Print help information
 
 To view the user documentation, please visit https://dbrgn.github.io/tealdeer/.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -299,7 +299,7 @@ impl Cache {
         let platforms_dir = self.pages_dir().join("pages");
         let platform_dirs: Vec<&'static str> = platforms
             .iter()
-            .map(|&p| Cache::get_platform_dir(p))
+            .map(|&p| Self::get_platform_dir(p))
             .collect();
 
         // Closure that allows the WalkDir instance to traverse platform

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,7 +20,6 @@ static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
 
 #[derive(Debug)]
 pub struct Cache {
-    platform: PlatformType,
     cache_dir: PathBuf,
 }
 
@@ -86,12 +85,11 @@ pub enum CacheFreshness {
 }
 
 impl Cache {
-    pub fn new<P>(platform: PlatformType, cache_dir: P) -> Self
+    pub fn new<P>(cache_dir: P) -> Self
     where
         P: Into<PathBuf>,
     {
         Self {
-            platform,
             cache_dir: cache_dir.into(),
         }
     }
@@ -211,8 +209,8 @@ impl Cache {
     }
 
     /// Return the platform directory.
-    fn get_platform_dir(&self) -> &'static str {
-        match self.platform {
+    fn get_platform_dir(platform: PlatformType) -> &'static str {
+        match platform {
             PlatformType::Linux => "linux",
             PlatformType::OsX => "osx",
             PlatformType::SunOs => "sunos",
@@ -247,6 +245,7 @@ impl Cache {
         name: &str,
         languages: &[String],
         custom_pages_dir: Option<&Path>,
+        platforms: &[PlatformType],
     ) -> Option<PageLookupResult> {
         let page_filename = format!("{}.md", name);
         let patch_filename = format!("{}.patch", name);
@@ -275,12 +274,14 @@ impl Cache {
 
         let patch_path = Self::find_patch(&patch_filename, custom_pages_dir);
 
-        // Try to find a platform specific path next, append custom patch to it.
-        let platform_dir = self.get_platform_dir();
-        if let Some(page) =
-            Self::find_page_for_platform(&page_filename, &pages_dir, platform_dir, &lang_dirs)
-        {
-            return Some(PageLookupResult::with_page(page).with_optional_patch(patch_path));
+        // Try to find a platform specific path next, in the order supplied by the user, and append custom patch to it.
+        for &platform in platforms {
+            let platform_dir = Cache::get_platform_dir(platform);
+            if let Some(page) =
+                Self::find_page_for_platform(&page_filename, &pages_dir, platform_dir, &lang_dirs)
+            {
+                return Some(PageLookupResult::with_page(page).with_optional_patch(patch_path));
+            }
         }
 
         // Did not find platform specific results, fall back to "common"
@@ -289,10 +290,17 @@ impl Cache {
     }
 
     /// Return the available pages.
-    pub fn list_pages(&self, custom_pages_dir: Option<&Path>) -> Vec<String> {
+    pub fn list_pages(
+        &self,
+        custom_pages_dir: Option<&Path>,
+        platforms: &[PlatformType],
+    ) -> Vec<String> {
         // Determine platforms directory and platform
         let platforms_dir = self.pages_dir().join("pages");
-        let platform_dir = self.get_platform_dir();
+        let platform_dirs: Vec<&'static str> = platforms
+            .iter()
+            .map(|&p| Cache::get_platform_dir(p))
+            .collect();
 
         // Closure that allows the WalkDir instance to traverse platform
         // specific and common page directories, but not others.
@@ -303,7 +311,7 @@ impl Cache {
                 None => return false,
             };
             if file_type.is_dir() {
-                return file_name == "common" || file_name == platform_dir;
+                return file_name == "common" || platform_dirs.contains(&file_name);
             } else if file_type.is_file() {
                 return true;
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,13 +2,13 @@
 
 use std::path::PathBuf;
 
-use clap::{AppSettings, ArgGroup, Parser};
+use clap::{AppSettings, ArgAction, ArgGroup, Parser};
 
 use crate::types::{ColorOptions, PlatformType};
 
 // Note: flag names are specified explicitly in clap attributes
 // to improve readability and allow contributors to grep names like "clear-cache"
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(about = "A fast TLDR client", author, version)]
 #[clap(
     after_help = "To view the user documentation, please visit https://dbrgn.github.io/tealdeer/."
@@ -39,9 +39,10 @@ pub(crate) struct Args {
     #[clap(
         short = 'p',
         long = "platform",
+        action = ArgAction::Append,
         possible_values = ["linux", "macos", "windows", "sunos", "osx", "android"],
     )]
-    pub platform: Option<PlatformType>,
+    pub platform: Option<Vec<PlatformType>>,
 
     /// Override the language
     #[clap(short = 'L', long = "language")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,7 +42,7 @@ pub(crate) struct Args {
         action = ArgAction::Append,
         possible_values = ["linux", "macos", "windows", "sunos", "osx", "android"],
     )]
-    pub platform: Option<Vec<PlatformType>>,
+    pub platforms: Option<Vec<PlatformType>>,
 
     /// Override the language
     #[clap(short = 'L', long = "language")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use crate::types::{ColorOptions, PlatformType};
 
 // Note: flag names are specified explicitly in clap attributes
 // to improve readability and allow contributors to grep names like "clear-cache"
-#[derive(Parser, Debug, Clone)]
+#[derive(Parser, Debug)]
 #[clap(about = "A fast TLDR client", author, version)]
 #[clap(
     after_help = "To view the user documentation, please visit https://dbrgn.github.io/tealdeer/."

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,7 @@ fn main() {
             .map(PathWithSource::path);
         println!(
             "{}",
-            cache.list_pages(custom_pages_dir, &platforms).join("\n")
+            cache.list_pages(custom_pages_dir, platforms).join("\n")
         );
         process::exit(0);
     }
@@ -356,7 +356,7 @@ fn main() {
                 .custom_pages_dir
                 .as_ref()
                 .map(PathWithSource::path),
-            &platforms,
+            platforms,
         ) {
             if let Err(ref e) =
                 print_page(&lookup_result, args.raw, enable_styles, args.pager, &config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,10 +280,11 @@ fn main() {
         create_config_and_exit(enable_styles);
     }
 
-    let platforms = match args.platform {
-        Some(ref platforms) => platforms.clone(),
-        None => vec![PlatformType::current()],
-    };
+    let fallback_platforms: &[PlatformType] = &[PlatformType::current()];
+    let platforms = args
+        .platform
+        .as_ref()
+        .map_or(fallback_platforms, Vec::as_slice);
 
     // If a local file was passed in, render it and exit
     if let Some(file) = args.render {
@@ -297,7 +298,7 @@ fn main() {
     }
 
     // Instantiate cache. This will not yet create the cache directory!
-    let cache = Cache::new(config.directories.cache_dir.path.clone());
+    let cache = Cache::new(&config.directories.cache_dir.path);
 
     // Clear cache, pass through
     if args.clear_cache {
@@ -370,8 +371,8 @@ fn main() {
                     enable_styles,
                     &format!(
                         "Page `{}` not found in cache.\n\
-                            Try updating with `tldr --update`, or submit a pull request to:\n\
-                            https://github.com/tldr-pages/tldr",
+                         Try updating with `tldr --update`, or submit a pull request to:\n\
+                         https://github.com/tldr-pages/tldr",
                         &command
                     ),
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,10 +281,10 @@ fn main() {
     }
 
     // Specify target OS
-    let platforms: Vec<PlatformType> = args
-        .clone()
-        .platform
-        .unwrap_or(vec![PlatformType::current()]);
+    let platforms: Vec<PlatformType> = match args.platform {
+        Some(ref p) => p.to_vec(),
+        None => vec![PlatformType::current()],
+    };
 
     // If a local file was passed in, render it and exit
     if let Some(file) = args.render {
@@ -300,9 +300,10 @@ fn main() {
     let mut err_cmd: Option<String> = None;
 
     // Collect languages
-    let languages = args.clone()
-        .language
-        .map_or_else(get_languages_from_env, |lang| vec![lang]);
+    let languages = match args.language {
+        Some(ref lang) => vec![lang.to_string()],
+        None => get_languages_from_env(),
+    };
 
     for platform in platforms {
         // Instantiate cache. This will not yet create the cache directory!

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn main() {
 
     // Specify target OS
     let platforms: Vec<PlatformType> = match args.platform {
-        Some(ref p) => p.to_vec(),
+        Some(ref p) => p.clone(),
         None => vec![PlatformType::current()],
     };
 
@@ -366,7 +366,7 @@ fn main() {
                 }
                 process::exit(0);
             } else {
-                err_cmd = Some(command)
+                err_cmd = Some(command);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn main() {
 
     let fallback_platforms: &[PlatformType] = &[PlatformType::current()];
     let platforms = args
-        .platform
+        .platforms
         .as_ref()
         .map_or(fallback_platforms, Vec::as_slice);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -566,12 +566,49 @@ fn test_pager_flag_enable() {
 fn test_multiple_platform_command_search() {
     let testenv = TestEnv::new();
     testenv.add_os_entry("linux", "linux-only", "this command only exists for linux");
+    testenv.add_os_entry(
+        "linux",
+        "windows-and-linux",
+        "# windows-and-linux \n\n > linux version",
+    );
+    testenv.add_os_entry(
+        "windows",
+        "windows-and-linux",
+        "# windows-and-linux \n\n > windows version",
+    );
 
     testenv
         .command()
-        .args(["--platform", "macos", "--platform", "linux", "linux-only"])
+        .args(["--platform", "windows", "--platform", "linux", "linux-only"])
         .assert()
         .success();
+
+    // test order of platforms supplied if preserved
+    testenv
+        .command()
+        .args([
+            "--platform",
+            "windows",
+            "--platform",
+            "linux",
+            "windows-and-linux",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("windows version"));
+
+    testenv
+        .command()
+        .args([
+            "--platform",
+            "linux",
+            "--platform",
+            "windows",
+            "windows-and-linux",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("linux version"));
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -563,6 +563,28 @@ fn test_pager_flag_enable() {
 }
 
 #[test]
+fn test_multiple_platform_command_search() {
+    let testenv = TestEnv::new();
+    testenv.add_os_entry("linux", "linux-only", "this command only exists for linux");
+
+    testenv.command()
+    .args(["--platform", "macos", "--platform", "linux", "linux-only"])
+    .assert()
+    .success();
+}
+
+#[test]
+fn test_multiple_platform_command_search_not_found() {
+    let testenv = TestEnv::new();
+    testenv.add_os_entry("windows", "windows-only", "this command only exists for Windows");
+
+    testenv.command()
+    .args(["--platform", "macos", "--platform", "linux", "windows-only"])
+    .assert()
+    .stderr(contains("Page `windows-only` not found in cache."));
+}
+
+#[test]
 fn test_list_flag_rendering() {
     let testenv = TestEnv::new();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -643,6 +643,30 @@ fn test_list_flag_rendering() {
         .assert()
         .failure()
         .stderr(contains("Page cache not found. Please run `tldr --update`"));
+
+    testenv.add_entry("foo", "");
+
+    testenv
+        .command()
+        .args(["--list"])
+        .assert()
+        .success()
+        .stdout("foo\n");
+
+    testenv.add_entry("bar", "");
+    testenv.add_entry("baz", "");
+    testenv.add_entry("qux", "");
+    testenv.add_page_entry("faz", "");
+    testenv.add_page_entry("bar", "");
+    testenv.add_page_entry("fiz", "");
+    testenv.add_patch_entry("buz", "");
+
+    testenv
+        .command()
+        .args(["--list"])
+        .assert()
+        .success()
+        .stdout("bar\nbaz\nfaz\nfiz\nfoo\nqux\n");
 }
 
 #[test]
@@ -654,13 +678,6 @@ fn test_multi_platform_list_flag_rendering() {
         "[directories]\ncustom_pages_dir = '{}'",
         testenv.custom_pages_dir.path().to_str().unwrap()
     ));
-
-    testenv
-        .command()
-        .args(["--list"])
-        .assert()
-        .failure()
-        .stderr(contains("Page cache not found. Please run `tldr --update`"));
 
     testenv.add_entry("common", "");
 
@@ -689,6 +706,8 @@ fn test_multi_platform_list_flag_rendering() {
     testenv.add_os_entry("linux", "ls", "");
     testenv.add_os_entry("windows", "del", "");
     testenv.add_os_entry("windows", "dir", "");
+    testenv.add_os_entry("linux", "winux", "");
+    testenv.add_os_entry("windows", "winux", "");
 
     // test `--list` for `--platform linux` by itself
     testenv
@@ -696,7 +715,7 @@ fn test_multi_platform_list_flag_rendering() {
         .args(["--platform", "linux", "--list"])
         .assert()
         .success()
-        .stdout("common\nls\nrm\n");
+        .stdout("common\nls\nrm\nwinux\n");
 
     // test `--list` for `--platform windows` by itself
     testenv
@@ -704,7 +723,7 @@ fn test_multi_platform_list_flag_rendering() {
         .args(["--platform", "windows", "--list"])
         .assert()
         .success()
-        .stdout("common\ndel\ndir\n");
+        .stdout("common\ndel\ndir\nwinux\n");
 
     // test `--list` for `--platform linux --platform windows`
     testenv
@@ -712,7 +731,7 @@ fn test_multi_platform_list_flag_rendering() {
         .args(["--platform", "linux", "--platform", "windows", "--list"])
         .assert()
         .success()
-        .stdout("common\ndel\ndir\nls\nrm\n");
+        .stdout("common\ndel\ndir\nls\nrm\nwinux\n");
 
     // test `--list` for `--platform windows --platform linux`
     testenv
@@ -720,7 +739,7 @@ fn test_multi_platform_list_flag_rendering() {
         .args(["--platform", "linux", "--platform", "windows", "--list"])
         .assert()
         .success()
-        .stdout("common\ndel\ndir\nls\nrm\n");
+        .stdout("common\ndel\ndir\nls\nrm\nwinux\n");
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -567,21 +567,27 @@ fn test_multiple_platform_command_search() {
     let testenv = TestEnv::new();
     testenv.add_os_entry("linux", "linux-only", "this command only exists for linux");
 
-    testenv.command()
-    .args(["--platform", "macos", "--platform", "linux", "linux-only"])
-    .assert()
-    .success();
+    testenv
+        .command()
+        .args(["--platform", "macos", "--platform", "linux", "linux-only"])
+        .assert()
+        .success();
 }
 
 #[test]
 fn test_multiple_platform_command_search_not_found() {
     let testenv = TestEnv::new();
-    testenv.add_os_entry("windows", "windows-only", "this command only exists for Windows");
+    testenv.add_os_entry(
+        "windows",
+        "windows-only",
+        "this command only exists for Windows",
+    );
 
-    testenv.command()
-    .args(["--platform", "macos", "--platform", "linux", "windows-only"])
-    .assert()
-    .stderr(contains("Page `windows-only` not found in cache."));
+    testenv
+        .command()
+        .args(["--platform", "macos", "--platform", "linux", "windows-only"])
+        .assert()
+        .stderr(contains("Page `windows-only` not found in cache."));
 }
 
 #[test]


### PR DESCRIPTION
Fix for an old issue #45 - to allow specifying multiple `platform`s on the cli.
Behaviour is to try get the tldr page for each platform given - so if a page doesn't exist for one platform but does for another, you still get the page displayed.