### PR TITLE
Add scoop package manager as supported installation method

### DIFF
--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -23,8 +23,8 @@ Tealdeer has been added to a few package managers:
 - NetBSD: [`sysutils/tealdeer`](https://pkgsrc.se/sysutils/tealdeer)
 - Nix: [`tealdeer`](https://nixos.org/nixos/packages.html#tealdeer)
 - openSUSE: [`tealdeer`](https://software.opensuse.org/package/tealdeer?search_term=tealdeer)
-- Solus: [`tealdeer`](https://packages.getsol.us/shannon/t/tealdeer/)
 - Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
+- Solus: [`tealdeer`](https://packages.getsol.us/shannon/t/tealdeer/)
 - Void Linux: [`tealdeer`](https://github.com/void-linux/void-packages/tree/master/srcpkgs/tealdeer)
 
 ## Static Binaries (Linux)

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -24,8 +24,8 @@ Tealdeer has been added to a few package managers:
 - Nix: [`tealdeer`](https://nixos.org/nixos/packages.html#tealdeer)
 - openSUSE: [`tealdeer`](https://software.opensuse.org/package/tealdeer?search_term=tealdeer)
 - Solus: [`tealdeer`](https://packages.getsol.us/shannon/t/tealdeer/)
+- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
 - Void Linux: [`tealdeer`](https://github.com/void-linux/void-packages/tree/master/srcpkgs/tealdeer)
-- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
 
 ## Static Binaries (Linux)
 

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -25,6 +25,7 @@ Tealdeer has been added to a few package managers:
 - openSUSE: [`tealdeer`](https://software.opensuse.org/package/tealdeer?search_term=tealdeer)
 - Solus: [`tealdeer`](https://packages.getsol.us/shannon/t/tealdeer/)
 - Void Linux: [`tealdeer`](https://github.com/void-linux/void-packages/tree/master/srcpkgs/tealdeer)
+- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
 
 ## Static Binaries (Linux)
 


### PR DESCRIPTION
Adds scoop as a supported installation method for tealdeer in docs.

It is present in the `main` repository of scoop which is enabled by default. So the only step needed to install `tealdeer` from scoop is `scoop install tealdeer`.