### PR TITLE
Docs: Fix typo (irregular space → regular space)

### DIFF
--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -23,7 +23,7 @@ Tealdeer has been added to a few package managers:
 - NetBSD: [`sysutils/tealdeer`](https://pkgsrc.se/sysutils/tealdeer)
 - Nix: [`tealdeer`](https://nixos.org/nixos/packages.html#tealdeer)
 - openSUSE: [`tealdeer`](https://software.opensuse.org/package/tealdeer?search_term=tealdeer)
-- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
+- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
 - Solus: [`tealdeer`](https://packages.getsol.us/shannon/t/tealdeer/)
 - Void Linux: [`tealdeer`](https://github.com/void-linux/void-packages/tree/master/srcpkgs/tealdeer)
 

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -23,7 +23,7 @@ Tealdeer has been added to a few package managers:
 - NetBSD: [`sysutils/tealdeer`](https://pkgsrc.se/sysutils/tealdeer)
 - Nix: [`tealdeer`](https://nixos.org/nixos/packages.html#tealdeer)
 - openSUSE: [`tealdeer`](https://software.opensuse.org/package/tealdeer?search_term=tealdeer)
-- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
+- Scoop: [`tealdeer`](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
 - Solus: [`tealdeer`](https://packages.getsol.us/shannon/t/tealdeer/)
 - Void Linux: [`tealdeer`](https://github.com/void-linux/void-packages/tree/master/srcpkgs/tealdeer)
 


### PR DESCRIPTION
It was a no-break space (U+00A0, `&nbsp;`), which causes mdBook to ignore the line break and [render wrongly](https://dbrgn.github.io/tealdeer/installing.html#package-managers).

Instead, a regular space (U+0020) should be used.

## Before

- openSUSE: [tealdeer](https://software.opensuse.org/package/tealdeer?search_term=tealdeer) - Scoop: [tealdeer](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
- Solus: [tealdeer](https://packages.getsol.us/shannon/t/tealdeer/)

## After

- openSUSE: [tealdeer](https://software.opensuse.org/package/tealdeer?search_term=tealdeer)
- Scoop: [tealdeer](https://github.com/ScoopInstaller/Main/blob/master/bucket/tealdeer.json)
- Solus: [tealdeer](https://packages.getsol.us/shannon/t/tealdeer/)