### PR TITLE
Line iterator: Improve test functions

### DIFF
--- a/src/line_iterator.rs
+++ b/src/line_iterator.rs
@@ -96,21 +96,27 @@ mod test {
 
     #[test]
     fn test_first_line_old_format() {
-        let input = "# The Title\n\n";
+        let input = "# The Title\n> Description\n";
         let mut lines = LineIterator::new(input.as_bytes());
         let title = lines.next().unwrap();
         assert_eq!(title, LineType::Title("The Title".to_string()));
-        let empty = lines.next().unwrap();
-        assert_eq!(empty, LineType::Empty);
+        let description = lines.next().unwrap();
+        assert_eq!(
+            description,
+            LineType::Description("Description".to_string())
+        );
     }
 
     #[test]
     fn test_first_line_new_format() {
-        let input = "The Title\n=========\n\n";
+        let input = "The Title\n=========\n> Description\n";
         let mut lines = LineIterator::new(input.as_bytes());
         let title = lines.next().unwrap();
         assert_eq!(title, LineType::Title("The Title".to_string()));
-        let empty = lines.next().unwrap();
-        assert_eq!(empty, LineType::Empty);
+        let description = lines.next().unwrap();
+        assert_eq!(
+            description,
+            LineType::Description("Description".to_string())
+        );
     }
 }


### PR DESCRIPTION
@niklasmohrin 
As you mentioned in #314, I improved test functions on `LineIterator`.
With your counter example code:
```rust
let mut previous = 0;
if let Err(e) = Read::bytes(&mut self.reader)
    .find(|b| {
        let res = previous == b'\n';
        previous = *b.as_ref().unwrap();
        res
    })
    .transpose()
```

The test function will fail:
```
❯ cargo test test_first_line
   Compiling tealdeer v1.6.1 (/home/potato/repos/tealdeer)
    Finished test [unoptimized + debuginfo] target(s) in 2.76s
     Running unittests src/main.rs (target/debug/deps/tldr-8d4cf65b28f436c9)

running 2 tests
test line_iterator::test::test_first_line_old_format ... ok
test line_iterator::test::test_first_line_new_format ... FAILED

failures:

---- line_iterator::test::test_first_line_new_format stdout ----
thread 'line_iterator::test::test_first_line_new_format' panicked at 'assertion failed: `(left == right)`
  left: `ExampleCode("Description")`,
 right: `Description("Description")`', src/line_iterator.rs:122:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    line_iterator::test::test_first_line_new_format

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s

error: test failed, to rerun pass `--bin tldr`
```
Do you think this is good enough? Or you have another idea?