### PR TITLE
Add config file option to set preferred language

### DIFF
--- a/docs/src/config_display.md
+++ b/docs/src/config_display.md
@@ -21,3 +21,10 @@ Set this to enforce more compact output, where empty lines are stripped out
 
     [display]
     compact = true
+
+## `language`
+
+Override the language.
+
+    [display]
+    language = "zh_CN"

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,7 @@ struct RawDisplayConfig {
     pub compact: bool,
     #[serde(default)]
     pub use_pager: bool,
+    pub language: Option<String>,
 }
 
 impl From<RawDisplayConfig> for DisplayConfig {
@@ -154,6 +155,7 @@ impl From<RawDisplayConfig> for DisplayConfig {
         Self {
             compact: raw_display_config.compact,
             use_pager: raw_display_config.use_pager,
+            language: raw_display_config.language,
         }
     }
 }
@@ -246,10 +248,11 @@ pub struct StyleConfig {
     pub example_variable: Style,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DisplayConfig {
     pub compact: bool,
     pub use_pager: bool,
+    pub language: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,7 @@ compile_error!(
     "exactly one of the features \"native-roots\", \"webpki-roots\" or \"native-tls\" must be enabled"
 );
 
-use std::iter::once;
-use std::{env, process};
+use std::{env, iter::once, process};
 
 use app_dirs::AppInfo;
 use atty::Stream;
@@ -203,6 +202,12 @@ fn init_log() {
 #[cfg(not(feature = "logging"))]
 fn init_log() {}
 
+/// Return language(s) with the following precedence:
+///
+/// 1. CLI language parameter (`-L`, `--language`)
+/// 2. Language as set in the config file
+/// 3. If the `$LANG` env var is set: `$LANGUAGE` (list separated by `:`) followed by `$LANG` (single language)
+/// 4. Fallback: English
 fn get_languages(
     command_line_lang: Option<&str>,
     config_lang: Option<&str>,
@@ -221,7 +226,7 @@ fn get_languages(
     } else if let Some(env_lang) = env_lang {
         env_language.chain(once(env_lang)).collect()
     } else {
-        env_language.collect()
+        Vec::new()
     };
 
     let mut lang_list = Vec::new();
@@ -418,7 +423,7 @@ mod test {
         #[test]
         fn only_language_env() {
             let lang_list = get_languages(None, None, None, Some("de:fr"));
-            assert_eq!(lang_list, ["de", "fr", "en"]);
+            assert_eq!(lang_list, ["en"]);
         }
 
         #[test]


### PR DESCRIPTION
This pull request enable users to write the following config:

```toml
[display]
language = "zh_CN"
```

to override the language.

Closes #251.