### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
        - uses: dtolnay/rust-toolchain@stable
          with:
            toolchain: stable
+           components: clippy
        - name: run clippy lints
          run: cargo clippy --features logging
 
@@ -45,6 +46,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          components: rustfmt
       - name: run rustfmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,14 @@ jobs:
     name: run tests
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        rust: ['1.62', stable]
+        platform: [ubuntu-latest, macos-latest, windows-latest, ubuntu-20.04]
+        toolchain: [stable, 1.62.1]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Build with default features
         run: cargo build
       - name: Build with logging and webpki roots
@@ -28,12 +31,20 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
+       - uses: actions/checkout@v3
+       - uses: dtolnay/rust-toolchain@stable
+         with:
+           toolchain: stable
        - name: run clippy lints
          run: cargo clippy --features logging
 
   fmt:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - name: run rustfmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     name: run tests
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest, ubuntu-20.04]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [stable, 1.62.1]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Build with default features
@@ -29,10 +29,11 @@ jobs:
         run: cargo test
 
   clippy:
+    name: run clippy lints
     runs-on: ubuntu-latest
     steps:
        - uses: actions/checkout@v3
-       - uses: dtolnay/rust-toolchain@stable
+       - uses: dtolnay/rust-toolchain@master
          with:
            toolchain: stable
            components: clippy
@@ -40,10 +41,11 @@ jobs:
          run: cargo clippy --features logging
 
   fmt:
+    name: run rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt
@@ -60,6 +62,9 @@ jobs:
         with:
           mdbook-version: '0.4.4'
       - name: Build
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: stable
         run: cargo build
       - name: Ensure that docs can be built
         run: cd docs && mdbook build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        rust: ['1.62', stable]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,11 @@ jobs:
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: '0.4.4'
-      - name: Build
+      - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable
+      - name: Build
         run: cargo build
       - name: Ensure that docs can be built
         run: cd docs && mdbook build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,79 +14,39 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        rust: ['1.62', stable]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          default: true
+      - uses: actions/checkout@v3
       - name: Build with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Build with logging and webpki roots
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features logging,webpki-roots --no-default-features
+        run: cargo build --features logging,webpki-roots --no-default-features
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
   clippy:
-    name: run clippy lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-          components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features logging
+       - name: run clippy lints
+         run: cargo clippy --features logging
 
   fmt:
-    name: run rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        default: true
-        components: rustfmt
-    - uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      - name: run rustfmt
+        run: fmt --all -- --check
 
   docs:
     name: build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: '0.4.4'
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Ensure that docs can be built
         run: cd docs && mdbook build
       - name: Generate usage string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: run rustfmt
-        run: fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   docs:
     name: build docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
            uses: dtolnay/rust-toolchain@master
            with:
               toolchain: stable
-           run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
+              command: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
       - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-macos-x86_64"
@@ -97,7 +97,7 @@ jobs:
        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable
-        run: cargo build --release --target x86_64-pc-windows-msvc
+           command: cargo build --release --target x86_64-pc-windows-msvc
       - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-windows-x86_64-msvc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ on:
   push:
     tags:
       - "v*" # push events to matching v*, i.e. v1.0, v20.15.10
-  workflow_dispatch:
 
 jobs:
   create-release:
@@ -81,7 +80,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
+           uses: dtolnay/rust-toolchain@master
+           with:
+              toolchain: stable
+           run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
       - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-macos-x86_64"
@@ -92,6 +94,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
+       uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: stable
         run: cargo build --release --target x86_64-pc-windows-msvc
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,13 @@ on:
   push:
     tags:
       - "v*" # push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create release for tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -18,12 +19,12 @@ jobs:
   upload-completions:
     needs:
       - create-release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target: ["bash", "fish", "zsh"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Upload completion
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -34,12 +35,12 @@ jobs:
   upload-license:
     needs:
       - create-release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target: ["MIT", "APACHE"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Upload license
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -48,7 +49,7 @@ jobs:
           upload_release_file ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${GITHUB_REF#refs/*/} LICENSE-${{ matrix.target }} LICENSE-${{ matrix.target }}.txt
 
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -63,42 +64,36 @@ jobs:
           - arch: "arm"
             libc: "musleabihf"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Pull Docker image
         run: docker pull messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }}
       - name: Build in Docker
         run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} cargo build --release
       - name: Strip binary
         run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} musl-strip -s /home/rust/src/target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-linux-${{ matrix.arch }}-${{ matrix.libc }}"
           path: "target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr"
 
   build-macos:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
-      - uses: actions/upload-artifact@v2
+        run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
+      - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-macos-x86_64"
           path: "target/x86_64-apple-darwin/release/tldr"
 
   build-windows:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target x86_64-pc-windows-msvc
-      - uses: actions/upload-artifact@v2
+        run: cargo build --release --target x86_64-pc-windows-msvc
+      - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-windows-x86_64-msvc"
           path: "target/x86_64-pc-windows-msvc/release/tldr.exe"
@@ -109,7 +104,7 @@ jobs:
       - build-linux
       - build-macos
       - build-windows
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -121,8 +116,8 @@ jobs:
           - macos-x86_64
           - windows-x86_64-msvc
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
       - name: Upload binary
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - name: Build
-           uses: dtolnay/rust-toolchain@master
-           with:
-              toolchain: stable
-              command: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
+        run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
       - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-macos-x86_64"
@@ -93,11 +94,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build
-       uses: dtolnay/rust-toolchain@master
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable
-           command: cargo build --release --target x86_64-pc-windows-msvc
+      - name: Build
+        run: cargo build --release --target x86_64-pc-windows-msvc
       - uses: actions/upload-artifact@v3
         with:
           name: "tealdeer-windows-x86_64-msvc"


### PR DESCRIPTION
## Changes

- Remove unmaintained rust actions and use the components directly in the [GitHub action runners](https://github.com/actions/runner-images).
- Update runners.
- Update toolchain to https://github.com/dtolnay/rust-toolchain.
- Bump the `actions/checkout` version to `v3` (Node 16).
- Bump the `actions/upload-artifact` version to `v3` (Node 16).
- Bump the `actions/download-artifact` version to `v3` (Node 16).