### PR TITLE
added checks for wrong `tldr --list` output in completions

### DIFF
--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -27,8 +27,9 @@ _tealdeer()
 		COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
 		return
 	fi
-
-	COMPREPLY=( $(compgen -W '$( tldr -l | tr -d , )' -- "${cur}") )
+	if tldrlist=$(tldr -l 2>/dev/null); then
+		COMPREPLY=( $(compgen -W '$( echo "$tldrlist" | tr -d , )' -- "${cur}") )
+	fi
 }
 
 complete -F _tealdeer tldr

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -2,8 +2,9 @@
 
 _applications() {
     local -a commands
-    commands=(${(uonzf)"$(tldr --list 2>/dev/null)"//:/\\:})
-    _describe -t commands 'command' commands
+    if commands=(${(uonzf)"$(tldr --list 2>/dev/null)"//:/\\:}); then
+        _describe -t commands 'command' commands
+    fi
 }
 
 _tealdeer() {


### PR DESCRIPTION
when tldr-pages doesnt exist (yet, as in, new installation), `tldr --list` will output something that makes no sense for the completions. I am not qualified to do a real fix, but the completions output did bug me enough to patch it for zsh and bash. I tried to patch it for fish as well but couldnt get the original completion to work so im leaving the problem for actual fish users. 

TL;DR:
Purpose: reduce annoyance during first use, which is important for user-friendliness
Method: patch completions with a simple if-no-error check, for zsh and bash.