### PR TITLE
Chore Guard Fish Completion When Cache Is Empty

### DIFF
--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -20,7 +20,9 @@ complete -c tldr      -l seed-config    -d 'Create a basic config.' -f
 complete -c tldr      -l color          -d 'Controls when to use color.' -xa 'always auto never'
 
 function __tealdeer_entries
-    tldr --list | string replace -a -i -r "\,\s" "\n"
+    if set entries (tldr --list  2>/dev/null)
+        string replace -a -i -r "\,\s" "\n" $entries
+    end
 end
 
 complete -f -c tldr -a '(__tealdeer_entries)'


### PR DESCRIPTION
See: #327 

I had fish installed and so implemented @niklasmohrin's suggestion.
Tested locally with:
 - empty cache (it does the right thing and doesn't output the error text)
 - `update`d cache (it does the right thing and still auto completes)