### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
 ]
 description = "Fetch and show tldr help pages for many CLI commands. Full featured offline client with caching support."
 homepage = "https://github.com/dbrgn/tealdeer/"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "tealdeer"
 readme = "README.md"
 repository = "https://github.com/dbrgn/tealdeer/"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields