### PR TITLE
Add "random" command to fetch random tldr page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ toml = "0.5.1"
 walkdir = "2.0.1"
 yansi = "0.5"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+rand = "0.8.5"
 
 [target.'cfg(not(windows))'.dependencies]
 pager = "0.16"

--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -6,7 +6,7 @@ _tealdeer()
 	_init_completion || return
 
 	case $prev in
-		-h|--help|-v|--version|-l|--list|-u|--update|--no-auto-update|-c|--clear-cache|--pager|-r|--raw|--show-paths|--seed-config|-q|--quiet)
+		-h|--help|-v|--version|-l|--list|-u|--update|--no-auto-update|-c|--clear-cache|--pager|-r|--raw|-R|--random|--show-paths|--seed-config|-q|--quiet)
 			return
 			;;
 		-f|--render)

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -14,6 +14,7 @@ complete -c tldr      -l no-auto-update -d 'If auto update is configured, disabl
 complete -c tldr -s c -l clear-cache    -d 'Clear the local cache.' -f
 complete -c tldr      -l pager          -d 'Use a pager to page output.' -f
 complete -c tldr -s r -l raw            -d 'Display the raw markdown instead of rendering it.' -f
+complete -c tldr -s R -l random         -d 'Display a random page.' -f
 complete -c tldr -s q -l quiet          -d 'Suppress informational messages.' -f
 complete -c tldr      -l show-paths     -d 'Show file and directory paths used by tealdeer.' -f
 complete -c tldr      -l seed-config    -d 'Create a basic config.' -f

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -28,6 +28,7 @@ _tealdeer() {
         "($I -c --clear-cache)"{-c,--clear-cache}"[Clear the local cache]"
         "($I)--pager[Use a pager to page output]"
         "($I -r --raw)"{-r,--raw}"[Display the raw markdown instead of rendering it]"
+        "($I -R --random)"{-R,--random}"[Display a random page]"
         "($I -q --quiet)"{-q,--quiet}"[Suppress informational messages]"
         "($I)--show-paths[Show file and directory paths used by tealdeer]"
         "($I)--seed-config[Create a basic config]"

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -19,6 +19,7 @@ OPTIONS:
     -c, --clear-cache             Clear the local cache
         --pager                   Use a pager to page output
     -r, --raw                     Display the raw markdown instead of rendering it
+    -R, --random                  Display a random page
     -q, --quiet                   Suppress informational messages
         --show-paths              Show file and directory paths used by tealdeer
         --seed-config             Create a basic config

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,7 +27,7 @@ pub struct Cache {
 impl Cache {
     pub fn random_page(&self, pages_dir: Option<&Path>, platforms: &[PlatformType]) -> Option<PageLookupResult> {
         return self.find_page(
-            &self.list_pages(pages_dir, platforms).choose(&mut rand::thread_rng()).unwrap(),
+            self.list_pages(pages_dir, platforms).choose(&mut rand::thread_rng()).unwrap(),
             &["en".to_string()],
             pages_dir,
             platforms,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{ensure, Context, Result};
 use log::debug;
+use rand::prelude::SliceRandom;
 use reqwest::{blocking::Client, Proxy};
 use walkdir::{DirEntry, WalkDir};
 use zip::ZipArchive;
@@ -21,6 +22,17 @@ static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
 #[derive(Debug)]
 pub struct Cache {
     cache_dir: PathBuf,
+}
+
+impl Cache {
+    pub fn random_page(&self, pages_dir: Option<&Path>, platforms: &[PlatformType]) -> Option<PageLookupResult> {
+        return self.find_page(
+            &self.list_pages(pages_dir, platforms).choose(&mut rand::thread_rng()).unwrap(),
+            &["en".to_string()],
+            pages_dir,
+            platforms,
+        );
+    }
 }
 
 #[derive(Debug)]
@@ -86,8 +98,8 @@ pub enum CacheFreshness {
 
 impl Cache {
     pub fn new<P>(cache_dir: P) -> Self
-    where
-        P: Into<PathBuf>,
+        where
+            P: Into<PathBuf>,
     {
         Self {
             cache_dir: cache_dir.into(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub(crate) struct Args {
     #[clap(short = 'r', long = "--raw", requires = "command_or_file")]
     pub raw: bool,
 
-    ///Get  a random tldr page command
+    /// Get a random command page
     #[clap(short = 'R', long = "--random")]
     pub random: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,10 @@ pub(crate) struct Args {
     #[clap(short = 'r', long = "--raw", requires = "command_or_file")]
     pub raw: bool,
 
+    ///Get  a random tldr page command
+    #[clap(short = 'R', long = "--random")]
+    pub random: bool,
+
     /// Suppress informational messages
     #[clap(short = 'q', long = "quiet")]
     pub quiet: bool,
@@ -79,6 +83,7 @@ pub(crate) struct Args {
     /// Create a basic config
     #[clap(long = "seed-config")]
     pub seed_config: bool,
+
 
     /// Control whether to use color
     #[clap(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,14 @@
 #![allow(clippy::too_many_lines)]
 
 #[cfg(any(
-    all(feature = "native-roots", feature = "webpki-roots"),
-    all(feature = "native-roots", feature = "native-tls"),
-    all(feature = "webpki-roots", feature = "native-tls"),
-    not(any(
-        feature = "native-roots",
-        feature = "webpki-roots",
-        feature = "native-tls"
-    )),
+all(feature = "native-roots", feature = "webpki-roots"),
+all(feature = "native-roots", feature = "native-tls"),
+all(feature = "webpki-roots", feature = "native-tls"),
+not(any(
+feature = "native-roots",
+feature = "webpki-roots",
+feature = "native-tls"
+)),
 ))]
 compile_error!(
     "exactly one of the features \"native-roots\", \"webpki-roots\" or \"native-tls\" must be enabled"
@@ -68,10 +68,10 @@ const ARCHIVE_URL: &str = "https://tldr.sh/assets/tldr.zip";
 fn should_update_cache(cache: &Cache, args: &Args, config: &Config) -> bool {
     args.update
         || (!args.no_auto_update
-            && config.updates.auto_update
-            && cache
-                .last_update()
-                .map_or(true, |ago| ago >= config.updates.auto_update_interval))
+        && config.updates.auto_update
+        && cache
+        .last_update()
+        .map_or(true, |ago| ago >= config.updates.auto_update_interval))
 }
 
 #[derive(PartialEq)]
@@ -247,9 +247,9 @@ fn main() {
 
     // Determine the usage of styles
     #[cfg(target_os = "windows")]
-    let ansi_support = yansi::Paint::enable_windows_ascii();
+        let ansi_support = yansi::Paint::enable_windows_ascii();
     #[cfg(not(target_os = "windows"))]
-    let ansi_support = true;
+        let ansi_support = true;
     let enable_styles = match args.color.unwrap_or_default() {
         // Attempt to use styling if instructed
         ColorOptions::Always => true,
@@ -336,6 +336,23 @@ fn main() {
             cache.list_pages(custom_pages_dir, platforms).join("\n")
         );
         process::exit(0);
+    }
+    // show random tldr page to client
+    if args.random {
+        let custom_pages_dir = config
+            .directories
+            .custom_pages_dir
+            .as_ref()
+            .map(PathWithSource::path);
+        if let Some(random_page) = cache.random_page(custom_pages_dir, platforms) {
+            match print_page(&random_page, args.raw, enable_styles, args.pager, &config) {
+                Ok(()) => process::exit(0),
+                Err(e) => {
+                    print_error(enable_styles, &e);
+                    process::exit(1);
+                }
+            }
+        }
     }
 
     // Show command from cache


### PR DESCRIPTION
Added a new `--random` command that allows users to get a random page from tldr(`tldr --random`). Logic for picking a random page were implemented in the `Cache` class. The `rand` crate was also included to handle random selection of pages. This new feature gives users a way to discover new commands they may not be aware of.

