### PR TITLE
rustdoc: add page

### DIFF
--- a/docs/rustdoc.md
+++ b/docs/rustdoc.md
@@ -1,0 +1,20 @@
+# rustdoc
+
+> Generate documentation for a Rust crate.
+> More information: <https://doc.rust-lang.org/stable/rustdoc/>
+
+- Generate documentation from the crate's root:
+
+`rustdoc {{src/lib.rs}}`
+
+- Pass a name for the project:
+
+`rustdoc {{src/lib.rs}} --crate-name {{name}}`
+
+- Generate documentation from Markdown files:
+
+`rustdoc {{file.md}}`
+
+- Specify the output directory:
+
+`rustdoc {{src/lib.rs}} --out-dir {{PATH}}`


### PR DESCRIPTION
Saw [this issue](https://github.com/tldr-pages/tldr/issues/10630) and thought maybe I could help. rustdoc's generate from Markdown feature is awesome - it needs a page too!