### PR TITLE
feat: add release build target "linux-aarch64-musl" for platform "linux/arm64"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
         include:
           - arch: "x86_64"
             libc: "musl"
+          - arch: "aarch64"
+            libc: "musl"
           - arch: "i686"
             libc: "musl"
           - arch: "armv7"
@@ -116,6 +118,7 @@ jobs:
       matrix:
         target:
           - linux-x86_64-musl
+          - linux-aarch64-musl
           - linux-i686-musl
           - linux-armv7-musleabihf
           - linux-arm-musleabi


### PR DESCRIPTION
First of all THANK YOU for all the work you put into `tealdeer` and this awesome open-source project in general ❤️ 

This PR adds support for the `linux/arm64` platform (which is required for i.e. Linux Docker images on Apple M1/M2/M3 Chips). 🚀 

I'd love to download the `linux/arm64` binary directly from releases in this repository in the future.
If possible please create a new release after merge.

I have tested the build process and binary release with a fictional `v1.6.2` release in my fork.

You can find the release here: [github.com/nifr/tealdeer/releases/tag/v1.6.2](https://github.com/nifr/tealdeer/releases/tag/v1.6.2)

Try it as follows:

```bash
# start a arm64 docker image
docker run --rm -it --platform=linux/arm64 debian:bullseye-slim

# download the binary
curl -sL \
 -o /usr/local/bin/tldr \
  https://github.com/nifr/tealdeer/releases/download/v1.6.2/tealdeer-linux-aarch64-musl
  
 # make it executable
chmod +x /usr/local/bin/tldr

# try "tldr" commands
tldr --update
tldr --version
LANGUAGE=en tldr git
LANGUAGE=de tldr git

# install "file" to inspect the binary
apt-get update
apt-get install -yq file

# show ELF information for the binary
file /usr/local/bin/tldr
```

Screenshot of my binary test on a MacBook Air 2023 (M2):

<img width="854" alt="Screenshot 2024-01-17 at 00 41 43" src="https://github.com/dbrgn/tealdeer/assets/851258/9246f51d-931b-4351-b054-106e2f897702">
