### PR TITLE
Bump MSRV to 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable, 1.62.1]
+        toolchain: [stable, 1.64.0]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/dbrgn/tealdeer/"
 documentation = "https://dbrgn.github.io/tealdeer/"
 version = "1.6.1"
 include = ["/src/**/*", "/tests/**/*", "/Cargo.toml", "/README.md", "/LICENSE-*", "/screenshot.png", "completion/*"]
-rust-version = "1.62"
+rust-version = "1.64"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
For clap v4 (#298), we need a higher MSRV, currently at least Rust 1.64.

Our MSRV policy is:

> When publishing a tealdeer release, the Rust version required to build it should be stable for at least a month.

I'd suggest to jump to 1.75. It's the current stable, released on December 28, and contains the "async fn in traits" change which makes it a potential synchronization point for libraries.