### PR TITLE
feat: add BSD platform support; chore: update workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         toolchain: [stable, 1.64.0]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -32,7 +32,7 @@ jobs:
     name: run clippy lints
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v4
        - uses: dtolnay/rust-toolchain@master
          with:
            toolchain: stable
@@ -44,7 +44,7 @@ jobs:
     name: run rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -56,7 +56,7 @@ jobs:
     name: build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create release for tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -23,7 +23,7 @@ jobs:
       matrix:
         target: ["bash", "fish", "zsh"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Upload completion
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -39,7 +39,7 @@ jobs:
       matrix:
         target: ["MIT", "APACHE"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Upload license
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -65,14 +65,14 @@ jobs:
           - arch: "arm"
             libc: "musleabihf"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Pull Docker image
         run: docker pull messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }}
       - name: Build in Docker
         run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} cargo build --release
       - name: Strip binary
         run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} musl-strip -s /home/rust/src/target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "tealdeer-linux-${{ matrix.arch }}-${{ matrix.libc }}"
           path: "target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr"
@@ -80,14 +80,14 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
       - name: Build
         run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "tealdeer-macos-x86_64"
           path: "target/x86_64-apple-darwin/release/tldr"
@@ -95,14 +95,14 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable
       - name: Build
         run: cargo build --release --target x86_64-pc-windows-msvc
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "tealdeer-windows-x86_64-msvc"
           path: "target/x86_64-pc-windows-msvc/release/tldr.exe"
@@ -126,8 +126,8 @@ jobs:
           - macos-x86_64
           - windows-x86_64-msvc
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
       - name: Upload binary
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Possible log types:
 - `[docs]` for documentation changes.
 - `[chore]` for maintenance work.
 
+
 ### [v1.6.1][v1.6.1] (2022-10-24)
 
 Changes:
@@ -26,6 +27,7 @@ Contributors to this version:
 - [Danilo Bargen][@dbrgn]
 
 Thanks!
+
 
 ### [v1.6.0][v1.6.0] (2022-10-02)
 
@@ -74,6 +76,7 @@ Contributors to this version:
 - [Simon Perdrisat][@gagarine]
 
 Thanks!
+
 
 ### [v1.5.0][v1.5.0] (2021-12-31)
 
@@ -162,6 +165,7 @@ Thanks!
 Last but not least, [Niklas Mohrin][@niklasmohrin] has joined the project as
 co-maintainer. Thank you for your help!
 
+
 ### [v1.4.1][v1.4.1] (2020-09-04)
 
 - [fixed] Syntax error in zsh completion file ([#138][i138])
@@ -173,6 +177,7 @@ Contributors to this version:
 - [Francesco][@BachoSeven]
 
 Thanks!
+
 
 ### [v1.4.0][v1.4.0] (2020-09-03)
 
@@ -194,6 +199,7 @@ Contributors to this version:
 - [Niklas Mohrin][@niklasmohrin]
 
 Thanks!
+
 
 ### [v1.3.0][v1.3.0] (2020-02-28)
 
@@ -219,6 +225,7 @@ Contributors to this version:
 - [Marc-André Renaud][@ma-renaud]
 
 Thanks!
+
 
 ### [v1.2.0][v1.2.0] (2019-08-10)
 
@@ -246,6 +253,7 @@ Contributors to this version:
 
 Thanks!
 
+
 ### [v1.1.0][v1.1.0] (2018-10-22)
 
 - [added] Configuration file support ([#43][i43])
@@ -263,6 +271,7 @@ Contributors to this version:
 
 Thanks!
 
+
 ### [v1.0.0][v1.0.0] (2018-02-11)
 
 - [added] Include bash completions ([#34][i34])
@@ -270,18 +279,22 @@ Thanks!
 - [changed] Require at least Rust 1.19 to build (previous: 1.9)
 - [changed] Improved unit/integration testing
 
+
 ### v0.4.0 (2016-11-25)
 
 - [added] Support for new page format
 - [changed] Update all dependencies
 
+
 ### v0.3.0 (2016-08-01)
 
 - [changed] Update curl dependency
 
+
 ### v0.2.0 (2016-04-16)
 
 - First crates.io release
+
 
 [@0ndorio]: https://github.com/0ndorio
 [@aldanor]: https://github.com/aldanor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Possible log types:
 - `[docs]` for documentation changes.
 - `[chore]` for maintenance work.
 
-
 ### [v1.6.1][v1.6.1] (2022-10-24)
 
 Changes:
@@ -27,7 +26,6 @@ Contributors to this version:
 - [Danilo Bargen][@dbrgn]
 
 Thanks!
-
 
 ### [v1.6.0][v1.6.0] (2022-10-02)
 
@@ -76,7 +74,6 @@ Contributors to this version:
 - [Simon Perdrisat][@gagarine]
 
 Thanks!
-
 
 ### [v1.5.0][v1.5.0] (2021-12-31)
 
@@ -165,7 +162,6 @@ Thanks!
 Last but not least, [Niklas Mohrin][@niklasmohrin] has joined the project as
 co-maintainer. Thank you for your help!
 
-
 ### [v1.4.1][v1.4.1] (2020-09-04)
 
 - [fixed] Syntax error in zsh completion file ([#138][i138])
@@ -177,7 +173,6 @@ Contributors to this version:
 - [Francesco][@BachoSeven]
 
 Thanks!
-
 
 ### [v1.4.0][v1.4.0] (2020-09-03)
 
@@ -199,7 +194,6 @@ Contributors to this version:
 - [Niklas Mohrin][@niklasmohrin]
 
 Thanks!
-
 
 ### [v1.3.0][v1.3.0] (2020-02-28)
 
@@ -225,7 +219,6 @@ Contributors to this version:
 - [Marc-André Renaud][@ma-renaud]
 
 Thanks!
-
 
 ### [v1.2.0][v1.2.0] (2019-08-10)
 
@@ -253,7 +246,6 @@ Contributors to this version:
 
 Thanks!
 
-
 ### [v1.1.0][v1.1.0] (2018-10-22)
 
 - [added] Configuration file support ([#43][i43])
@@ -271,7 +263,6 @@ Contributors to this version:
 
 Thanks!
 
-
 ### [v1.0.0][v1.0.0] (2018-02-11)
 
 - [added] Include bash completions ([#34][i34])
@@ -279,22 +270,18 @@ Thanks!
 - [changed] Require at least Rust 1.19 to build (previous: 1.9)
 - [changed] Improved unit/integration testing
 
-
 ### v0.4.0 (2016-11-25)
 
 - [added] Support for new page format
 - [changed] Update all dependencies
 
-
 ### v0.3.0 (2016-08-01)
 
 - [changed] Update curl dependency
 
-
 ### v0.2.0 (2016-04-16)
 
 - First crates.io release
-
 
 [@0ndorio]: https://github.com/0ndorio
 [@aldanor]: https://github.com/aldanor

--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -14,7 +14,7 @@ _tealdeer()
 			return
 			;;
 		-p|--platform)
-			COMPREPLY=( $(compgen -W 'common linux macos sunos windows android freebsd netbsd openbsd' -- "${cur}") )
+			COMPREPLY=( $(compgen -W 'linux macos sunos windows android freebsd netbsd openbsd' -- "${cur}") )
 			return
 			;;
 		--color)

--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -14,7 +14,7 @@ _tealdeer()
 			return
 			;;
 		-p|--platform)
-			COMPREPLY=( $(compgen -W 'linux macos sunos windows android' -- "${cur}") )
+			COMPREPLY=( $(compgen -W 'linux macos sunos windows android freebsd netbsd openbsd' -- "${cur}") )
 			return
 			;;
 		--color)

--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -14,7 +14,7 @@ _tealdeer()
 			return
 			;;
 		-p|--platform)
-			COMPREPLY=( $(compgen -W 'linux macos sunos windows android freebsd netbsd openbsd' -- "${cur}") )
+			COMPREPLY=( $(compgen -W 'common linux macos sunos windows android freebsd netbsd openbsd' -- "${cur}") )
 			return
 			;;
 		--color)

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -7,7 +7,7 @@ complete -c tldr -s h -l help           -d 'Print the help message.' -f
 complete -c tldr -s v -l version        -d 'Show version information.' -f
 complete -c tldr -s l -l list           -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render         -d 'Render a specific markdown file.' -r
-complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows android'
+complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows android freebsd netbsd openbsd'
 complete -c tldr -s L -l language       -d 'Override the language' -x
 complete -c tldr -s u -l update         -d 'Update the local cache.' -f
 complete -c tldr      -l no-auto-update -d 'If auto update is configured, disable it for this run.' -f

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -7,7 +7,7 @@ complete -c tldr -s h -l help           -d 'Print the help message.' -f
 complete -c tldr -s v -l version        -d 'Show version information.' -f
 complete -c tldr -s l -l list           -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render         -d 'Render a specific markdown file.' -r
-complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'common linux macos sunos windows android freebsd netbsd openbsd'
+complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows android freebsd netbsd openbsd'
 complete -c tldr -s L -l language       -d 'Override the language' -x
 complete -c tldr -s u -l update         -d 'Update the local cache.' -f
 complete -c tldr      -l no-auto-update -d 'If auto update is configured, disable it for this run.' -f

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -7,7 +7,7 @@ complete -c tldr -s h -l help           -d 'Print the help message.' -f
 complete -c tldr -s v -l version        -d 'Show version information.' -f
 complete -c tldr -s l -l list           -d 'List all commands in the cache.' -f
 complete -c tldr -s f -l render         -d 'Render a specific markdown file.' -r
-complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'linux macos sunos windows android freebsd netbsd openbsd'
+complete -c tldr -s p -l platform       -d 'Override the operating system.' -xa 'common linux macos sunos windows android freebsd netbsd openbsd'
 complete -c tldr -s L -l language       -d 'Override the language' -x
 complete -c tldr -s u -l update         -d 'Update the local cache.' -f
 complete -c tldr      -l no-auto-update -d 'If auto update is configured, disable it for this run.' -f

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -16,6 +16,7 @@ _tealdeer() {
         "($I -l --list)"{-l,--list}"[List all commands in the cache]"
         "($I -f --render)"{-f,--render}"[Render a specific markdown file]:file:_files"
         "($I -p --platform)"{-p,--platform}'[Override the operating system]:platform:((
+            common
             linux
             macos
             sunos

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -21,6 +21,9 @@ _tealdeer() {
             sunos
             windows
             android
+            freebsd
+            netbsd
+            openbsd
         ))'
         "($I -L --language)"{-L,--language}"[Override the language settings]:lang"
         "($I -u --update)"{-u,--update}"[Update the local cache]"

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -16,7 +16,6 @@ _tealdeer() {
         "($I -l --list)"{-l,--list}"[List all commands in the cache]"
         "($I -f --render)"{-f,--render}"[Render a specific markdown file]:file:_files"
         "($I -p --platform)"{-p,--platform}'[Override the operating system]:platform:((
-            common
             linux
             macos
             sunos

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -11,8 +11,8 @@ ARGS:
 OPTIONS:
     -l, --list                    List all commands in the cache
     -f, --render <FILE>           Render a specific markdown file
-    -p, --platform <PLATFORMS>    Override the operating system [possible values: linux, macos,
-                                  windows, sunos, osx, android, freebsd, netbsd, openbsd]
+    -p, --platform <PLATFORMS>    Override the operating system [possible values: common, linux,
+                                  macos, windows, sunos, osx, android, freebsd, netbsd, openbsd]
     -L, --language <LANGUAGE>     Override the language
     -u, --update                  Update the local cache
         --no-auto-update          If auto update is configured, disable it for this run

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -12,7 +12,7 @@ OPTIONS:
     -l, --list                    List all commands in the cache
     -f, --render <FILE>           Render a specific markdown file
     -p, --platform <PLATFORMS>    Override the operating system [possible values: linux, macos,
-                                  windows, sunos, osx, android]
+                                  windows, sunos, osx, android, freebsd, netbsd, openbsd]
     -L, --language <LANGUAGE>     Override the language
     -u, --update                  Update the local cache
         --no-auto-update          If auto update is configured, disable it for this run

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -11,8 +11,8 @@ ARGS:
 OPTIONS:
     -l, --list                    List all commands in the cache
     -f, --render <FILE>           Render a specific markdown file
-    -p, --platform <PLATFORMS>    Override the operating system [possible values: common, linux,
-                                  macos, windows, sunos, osx, android, freebsd, netbsd, openbsd]
+    -p, --platform <PLATFORMS>    Override the operating system [possible values: linux, macos,
+                                  windows, sunos, osx, android, freebsd, netbsd, openbsd]
     -L, --language <LANGUAGE>     Override the language
     -u, --update                  Update the local cache
         --no-auto-update          If auto update is configured, disable it for this run

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -213,6 +213,7 @@ impl Cache {
     /// Return the platform directory.
     fn get_platform_dir(platform: PlatformType) -> &'static str {
         match platform {
+            PlatformType::Common => "common",
             PlatformType::Linux => "linux",
             PlatformType::OsX => "osx",
             PlatformType::SunOs => "sunos",

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -213,7 +213,6 @@ impl Cache {
     /// Return the platform directory.
     fn get_platform_dir(platform: PlatformType) -> &'static str {
         match platform {
-            PlatformType::Common => "common",
             PlatformType::Linux => "linux",
             PlatformType::OsX => "osx",
             PlatformType::SunOs => "sunos",

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -218,6 +218,9 @@ impl Cache {
             PlatformType::SunOs => "sunos",
             PlatformType::Windows => "windows",
             PlatformType::Android => "android",
+            PlatformType::FreeBSD => "freebsd",
+            PlatformType::NetBSD => "netbsd",
+            PlatformType::OpenBSD => "openbsd",
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -218,9 +218,9 @@ impl Cache {
             PlatformType::SunOs => "sunos",
             PlatformType::Windows => "windows",
             PlatformType::Android => "android",
-            PlatformType::FreeBSD => "freebsd",
-            PlatformType::NetBSD => "netbsd",
-            PlatformType::OpenBSD => "openbsd",
+            PlatformType::FreeBsd => "freebsd",
+            PlatformType::NetBsd => "netbsd",
+            PlatformType::OpenBsd => "openbsd",
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub(crate) struct Args {
         short = 'p',
         long = "platform",
         action = ArgAction::Append,
-        possible_values = ["linux", "macos", "windows", "sunos", "osx", "android", "freebsd", "netbsd", "openbsd"],
+        possible_values = ["common", "linux", "macos", "windows", "sunos", "osx", "android", "freebsd", "netbsd", "openbsd"],
     )]
     pub platforms: Option<Vec<PlatformType>>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub(crate) struct Args {
         short = 'p',
         long = "platform",
         action = ArgAction::Append,
-        possible_values = ["linux", "macos", "windows", "sunos", "osx", "android"],
+        possible_values = ["linux", "macos", "windows", "sunos", "osx", "android", "freebsd", "netbsd", "openbsd"],
     )]
     pub platforms: Option<Vec<PlatformType>>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub(crate) struct Args {
         short = 'p',
         long = "platform",
         action = ArgAction::Append,
-        possible_values = ["common", "linux", "macos", "windows", "sunos", "osx", "android", "freebsd", "netbsd", "openbsd"],
+        possible_values = ["linux", "macos", "windows", "sunos", "osx", "android", "freebsd", "netbsd", "openbsd"],
     )]
     pub platforms: Option<Vec<PlatformType>>,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,9 +14,9 @@ pub enum PlatformType {
     SunOs,
     Windows,
     Android,
-    FreeBSD,
-    NetBSD,
-    OpenBSD,
+    FreeBsd,
+    NetBsd,
+    OpenBsd,
 }
 
 impl fmt::Display for PlatformType {
@@ -76,17 +76,17 @@ impl PlatformType {
         Self::Android
     }
 
-    #[cfg(any(target_os = "freebsd",))]
+    #[cfg(any(target_os = "freebsd"))]
     pub fn current() -> Self {
         Self::FreeBSD
     }
 
-    #[cfg(any(target_os = "netbsd",))]
+    #[cfg(any(target_os = "netbsd"))]
     pub fn current() -> Self {
         Self::NetBSD
     }
 
-    #[cfg(any(target_os = "openbsd",))]
+    #[cfg(any(target_os = "openbsd"))]
     pub fn current() -> Self {
         Self::OpenBSD
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,9 +27,9 @@ impl fmt::Display for PlatformType {
             Self::SunOs => write!(f, "SunOS"),
             Self::Windows => write!(f, "Windows"),
             Self::Android => write!(f, "Android"),
-            Self::FreeBSD => write!(f, "FreeBSD"),
-            Self::NetBSD => write!(f, "NetBSD"),
-            Self::OpenBSD => write!(f, "OpenBSD"),
+            Self::FreeBsd => write!(f, "FreeBSD"),
+            Self::NetBsd => write!(f, "NetBSD"),
+            Self::OpenBsd => write!(f, "OpenBSD"),
         }
     }
 }
@@ -44,9 +44,9 @@ impl str::FromStr for PlatformType {
             "sunos" => Ok(Self::SunOs),
             "windows" => Ok(Self::Windows),
             "android" => Ok(Self::Android),
-            "freebsd" => Ok(Self::FreeBSD),
-            "netbsd" => Ok(Self::NetBSD),
-            "openbsd" => Ok(Self::OpenBSD),
+            "freebsd" => Ok(Self::FreeBsd),
+            "netbsd" => Ok(Self::NetBsd),
+            "openbsd" => Ok(Self::OpenBsd),
             other => Err(anyhow!(
                 "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows, android, freebsd, netbsd, openbsd",
                 other
@@ -78,17 +78,17 @@ impl PlatformType {
 
     #[cfg(any(target_os = "freebsd"))]
     pub fn current() -> Self {
-        Self::FreeBSD
+        Self::FreeBsd
     }
 
     #[cfg(any(target_os = "netbsd"))]
     pub fn current() -> Self {
-        Self::NetBSD
+        Self::NetBsd
     }
 
     #[cfg(any(target_os = "openbsd"))]
     pub fn current() -> Self {
-        Self::OpenBSD
+        Self::OpenBsd
     }
 
     #[cfg(not(any(

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ use serde_derive::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)]
 pub enum PlatformType {
+    Common,
     Linux,
     OsX,
     SunOs,
@@ -22,6 +23,7 @@ pub enum PlatformType {
 impl fmt::Display for PlatformType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::Common => write!(f, "Common"),
             Self::Linux => write!(f, "Linux"),
             Self::OsX => write!(f, "macOS / BSD"),
             Self::SunOs => write!(f, "SunOS"),
@@ -39,6 +41,7 @@ impl str::FromStr for PlatformType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "common" => Ok(Self::Common),
             "linux" => Ok(Self::Linux),
             "osx" | "macos" => Ok(Self::OsX),
             "sunos" => Ok(Self::SunOs),
@@ -48,7 +51,7 @@ impl str::FromStr for PlatformType {
             "netbsd" => Ok(Self::NetBSD),
             "openbsd" => Ok(Self::OpenBSD),
             other => Err(anyhow!(
-                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows, android, freebsd, netbsd, openbsd",
+                "Unknown OS: {}. Possible values: common, linux, macos, osx, sunos, windows, android, freebsd, netbsd, openbsd",
                 other
             )),
         }
@@ -91,7 +94,13 @@ impl PlatformType {
         Self::OpenBSD
     }
 
+    #[cfg(any(target_os = "common",))]
+    pub fn current() -> Self {
+        Self::Common
+    }
+
     #[cfg(not(any(
+        target_os = "common",
         target_os = "linux",
         target_os = "macos",
         target_os = "freebsd",

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Shared types used in tealdeer.
 
-use std::{fmt, str};
+use std::{fmt::{self, write}, str};
 
 use anyhow::{anyhow, Result};
 use serde_derive::{Deserialize, Serialize};
@@ -14,6 +14,9 @@ pub enum PlatformType {
     SunOs,
     Windows,
     Android,
+    FreeBSD,
+    NetBSD,
+    OpenBSD,
 }
 
 impl fmt::Display for PlatformType {
@@ -24,6 +27,9 @@ impl fmt::Display for PlatformType {
             Self::SunOs => write!(f, "SunOS"),
             Self::Windows => write!(f, "Windows"),
             Self::Android => write!(f, "Android"),
+            Self::FreeBSD => write!(f, "FreeBSD"),
+            Self::NetBSD => write!(f, "NetBSD"),
+            Self::OpenBSD => write!(f, "OpenBSD"),
         }
     }
 }
@@ -38,8 +44,11 @@ impl str::FromStr for PlatformType {
             "sunos" => Ok(Self::SunOs),
             "windows" => Ok(Self::Windows),
             "android" => Ok(Self::Android),
+            "freebsd" => Ok(Self::FreeBSD),
+            "netbsd" => Ok(Self::NetBSD),
+            "openbsd" => Ok(Self::OpenBSD),
             other => Err(anyhow!(
-                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows, android",
+                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows, android, freebsd, netbsd, openbsd",
                 other
             )),
         }
@@ -54,9 +63,6 @@ impl PlatformType {
 
     #[cfg(any(
         target_os = "macos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
         target_os = "dragonfly"
     ))]
     pub fn current() -> Self {
@@ -71,6 +77,27 @@ impl PlatformType {
     #[cfg(target_os = "android")]
     pub fn current() -> Self {
         Self::Android
+    }
+
+    #[cfg(any(
+        target_os = "freebsd",
+    ))]
+    pub fn current() -> Self {
+        Self::FreeBSD
+    }
+
+    #[cfg(any(
+        target_os = "netbsd",
+    ))]
+    pub fn current() -> Self {
+        Self::NetBSD
+    }
+
+    #[cfg(any(
+        target_os = "openbsd",
+    ))]
+    pub fn current() -> Self {
+        Self::OpenBSD
     }
 
     #[cfg(not(any(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Shared types used in tealdeer.
 
-use std::{fmt::{self, write}, str};
+use std::{fmt, str};
 
 use anyhow::{anyhow, Result};
 use serde_derive::{Deserialize, Serialize};
@@ -61,10 +61,7 @@ impl PlatformType {
         Self::Linux
     }
 
-    #[cfg(any(
-        target_os = "macos",
-        target_os = "dragonfly"
-    ))]
+    #[cfg(any(target_os = "macos", target_os = "dragonfly"))]
     pub fn current() -> Self {
         Self::OsX
     }
@@ -79,23 +76,17 @@ impl PlatformType {
         Self::Android
     }
 
-    #[cfg(any(
-        target_os = "freebsd",
-    ))]
+    #[cfg(any(target_os = "freebsd",))]
     pub fn current() -> Self {
         Self::FreeBSD
     }
 
-    #[cfg(any(
-        target_os = "netbsd",
-    ))]
+    #[cfg(any(target_os = "netbsd",))]
     pub fn current() -> Self {
         Self::NetBSD
     }
 
-    #[cfg(any(
-        target_os = "openbsd",
-    ))]
+    #[cfg(any(target_os = "openbsd",))]
     pub fn current() -> Self {
         Self::OpenBSD
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,6 @@ use serde_derive::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)]
 pub enum PlatformType {
-    Common,
     Linux,
     OsX,
     SunOs,
@@ -23,7 +22,6 @@ pub enum PlatformType {
 impl fmt::Display for PlatformType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Common => write!(f, "Common"),
             Self::Linux => write!(f, "Linux"),
             Self::OsX => write!(f, "macOS / BSD"),
             Self::SunOs => write!(f, "SunOS"),
@@ -41,7 +39,6 @@ impl str::FromStr for PlatformType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "common" => Ok(Self::Common),
             "linux" => Ok(Self::Linux),
             "osx" | "macos" => Ok(Self::OsX),
             "sunos" => Ok(Self::SunOs),
@@ -51,7 +48,7 @@ impl str::FromStr for PlatformType {
             "netbsd" => Ok(Self::NetBSD),
             "openbsd" => Ok(Self::OpenBSD),
             other => Err(anyhow!(
-                "Unknown OS: {}. Possible values: common, linux, macos, osx, sunos, windows, android, freebsd, netbsd, openbsd",
+                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows, android, freebsd, netbsd, openbsd",
                 other
             )),
         }
@@ -94,13 +91,7 @@ impl PlatformType {
         Self::OpenBSD
     }
 
-    #[cfg(any(target_os = "common",))]
-    pub fn current() -> Self {
-        Self::Common
-    }
-
     #[cfg(not(any(
-        target_os = "common",
         target_os = "linux",
         target_os = "macos",
         target_os = "freebsd",


### PR DESCRIPTION
## Changes

- This PR adds support for FreeBSD, NetBSD and OpenBSD platforms that we recently added upstream (I announced it as part of the 2.1 client specification release last year).
- ~This PR also adds support for querying the common platform via a dedicated flag for #323.~ (This didn't work during testing so will revert it)
- Bump `actions` from `v3` (Node 16) to `v4` (Node 20).
- Added GitHub dependabot configuration to automate these dependency updates for GitHub actions as well as Cargo (dependabot will create PRs monthly to update these dependencies).
- Fix spacing in the changelog.

For #349