### PR TITLE
performance optimize with cargo flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,7 @@ webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 native-tls = ["reqwest/native-tls"]
 
 [profile.release]
+strip = true
+opt-level = 3
 lto = true
+codegen-units = 1


### PR DESCRIPTION
```
Benchmark 1: tldr ip
  Time (mean ± σ):       2.9 ms ±   0.2 ms    [User: 1.0 ms, System: 1.6 ms]
  Range (min … max):     2.0 ms …   3.6 ms    500 runs

Benchmark 2: ./target/release/tldr ip
  Time (mean ± σ):       2.6 ms ±   0.2 ms    [User: 1.2 ms, System: 1.1 ms]
  Range (min … max):     1.8 ms …   3.4 ms    500 runs

Summary
  ./target/release/tldr ip ran
    1.15 ± 0.13 times faster than tldr ip
```