### PR TITLE
Generate docs only upon release

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,8 +2,8 @@ name: github pages
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*" # push events matching `v` followed by anything, e.g. v1.0, v20.15.10
 
 jobs:
   deploy:


### PR DESCRIPTION
Small PR to implement the stop-gap solution discussed in Issue #358 (https://github.com/dbrgn/tealdeer/issues/358#issuecomment-2045967635)

Makes the gh-pages workflow run only on version tag push (i.e. release).