### PR TITLE
CI: Create release builds for Apple silicon (ARM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+name: CI
 on:
   push:
     branches:
@@ -5,8 +6,6 @@ on:
   pull_request:
   schedule:
     - cron: '30 3 * * 2'
-
-name: CI
 
 jobs:
   test:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     tags:
-      - "v*" # push events matching `v` followed by anything, e.g. v1.0, v20.15.10
+      - "v[1-9]*" # push events matching `v` followed by anything larger than 0, e.g. v1.0, v20.15.10
 
 jobs:
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,4 @@
-name: github pages
-
+name: GitHub Pages
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: Release
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,18 +79,24 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - arch: "x86_64"
+          - arch: "aarch64"
     steps:
       - uses: actions/checkout@v4
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+          targets: "${{ matrix.arch }}-apple-darwin"
       - name: Build
-        run: cargo build --release --target x86_64-apple-darwin --no-default-features --features webpki-roots
+        run: cargo build --release --target ${{ matrix.arch }}-apple-darwin --no-default-features --features webpki-roots
       - uses: actions/upload-artifact@v4
         with:
-          name: "tealdeer-macos-x86_64"
-          path: "target/x86_64-apple-darwin/release/tldr"
+          name: "tealdeer-macos-${{ matrix.arch }}"
+          path: "target/${{ matrix.arch }}-apple-darwin/release/tldr"
 
   build-windows:
     runs-on: windows-latest
@@ -124,6 +130,7 @@ jobs:
           - linux-arm-musleabi
           - linux-arm-musleabihf
           - macos-x86_64
+          - macos-aarch64
           - windows-x86_64-msvc
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Create release builds for Apple's ARM machines as well.

Fixes #365.