### PR TITLE
CI: use ARM Linux runner for tests and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: run tests
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         toolchain: [stable, 1.75.0]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,27 @@ jobs:
         include:
           - arch: "x86_64"
             libc: "musl"
-          - arch: "aarch64"
-            libc: "musl"
           - arch: "i686"
+            libc: "musl"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pull Docker image
+        run: docker pull messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }}
+      - name: Build in Docker
+        run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} cargo build --release
+      - name: Strip binary
+        run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} musl-strip -s /home/rust/src/target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "tealdeer-linux-${{ matrix.arch }}-${{ matrix.libc }}"
+          path: "target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr"
+
+  build-linux-arm:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        include:
+          - arch: "aarch64"
             libc: "musl"
           - arch: "armv7"
             libc: "musleabihf"
@@ -76,7 +94,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: "tealdeer-linux-${{ matrix.arch }}-${{ matrix.libc }}"
-          path: "target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr"
+          path: "target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr"  
 
   build-macos:
     runs-on: macos-latest
@@ -118,6 +136,7 @@ jobs:
     needs:
       - create-release
       - build-linux
+      - build-linux-arm
       - build-macos
       - build-windows
     runs-on: ubuntu-latest


### PR DESCRIPTION
test release: https://github.com/theofficialgman/tealdeer/actions/runs/14022597794
test CI: https://github.com/theofficialgman/tealdeer/actions/runs/14022594689

you will note that currently all the linux release runners are failing (unrelated to this PR) due to not have openssl in the musl docker container

in the future I hope that the tests could be expanded (to include all the same cross compiles as the release targets) to catch these sort of issues https://github.com/tealdeer-rs/tealdeer/issues/419