### PR TITLE
Add builtin `tldr tealdeer` page

### DIFF
--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -29,3 +29,5 @@ Options:
   -h, --help                 Print help
 
 To view the user documentation, please visit https://tealdeer-rs.github.io/tealdeer/.
+
+To view usage examples, run tldr tldr or tldr tealdeer.

--- a/pages/tealdeer.md
+++ b/pages/tealdeer.md
@@ -1,25 +1,9 @@
 # tldr
 
-> A fast tldr client written in Rust.
+> This is a builtin page that shows information for your installed tealdeer version.
 > More information: <https://tealdeer-rs.github.io/tealdeer/>.
 
-- Show the tldr page for a command:
-
-`tldr {{command}}`
-
-- Show the tldr page for a subcommand:
-
-`tldr {{command}} {{subcommand}}`
-
-- Show the tldr page for a specific platform:
-
-`tldr --platform {{android|common|freebsd|linux|netbsd|openbsd|osx|sunos|windows}} {{command}}`
-
-- Show the tldr page in a specific language:
-
-`tldr --language {{language_code}} {{command}}`
-
-- Download or update the local page cache:
+> This page shows tealdeer specific functionality. See tldr tldr for more examples.
 
 `tldr --update`
 

--- a/pages/tealdeer.md
+++ b/pages/tealdeer.md
@@ -5,12 +5,6 @@
 
 > This page shows tealdeer specific functionality. See tldr tldr for more examples.
 
-`tldr --update`
-
-- List all pages in the cache:
-
-`tldr --list`
-
 - Render a local markdown file as a tldr page:
 
 `tldr --render {{path/to/file.md}}`
@@ -27,6 +21,10 @@
 
 `tldr --seed-config`
 
+- Override config file location:
+
+`tldr --config-path <FILE>`
+
 - Open a custom page for a command in `$EDITOR` (creates it if it doesn't exist):
 
 `tldr --edit-page {{command}}`
@@ -38,3 +36,7 @@
 - Clear the local cache:
 
 `tldr --clear-cache`
+
+- If auto update is configured, disable it for this run:
+
+`tldr --no-auto-update`

--- a/pages/tldr.md
+++ b/pages/tldr.md
@@ -1,0 +1,37 @@
+# tldr
+
+> Display simple help pages for command-line tools from the tldr-pages project.
+> Note: The `--language` and `--list` options are not required by the client specification, but most clients implement them.
+> More information: <https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#command-line-interface>.
+
+- Print the tldr page for a specific command (hint: this is how you got here!):
+
+`tldr {{command}}`
+
+- Print the tldr page for a specific subcommand:
+
+`tldr {{command}} {{subcommand}}`
+
+- Print the tldr page for a command in the given language (if available, otherwise fall back to English):
+
+`tldr {{[-L|--language]}} {{language_code}} {{command}}`
+
+- Print the tldr page for a command from a specific platform:
+
+`tldr {{[-p|--platform]}} {{android|cisco-ios|common|dos|freebsd|linux|netbsd|openbsd|osx|sunos|windows}} {{command}}`
+
+- Update the local cache of tldr pages:
+
+`tldr {{[-u|--update]}}`
+
+- List all pages for the current platform and `common`:
+
+`tldr {{[-l|--list]}}`
+
+- Browse tldr pages in a terminal window (`fzf` must be available):
+
+`tldr {{[-l|--list]}} | fzf --preview "tldr {1} --color=always" --preview-window=right,70% | xargs tldr`
+
+- Print the tldr page for a random command:
+
+`tldr {{[-l|--list]}} | shuf {{[-n|--head-count]}} 1 | xargs tldr`

--- a/pages/tldr.md
+++ b/pages/tldr.md
@@ -1,37 +1,56 @@
 # tldr
 
-> Display simple help pages for command-line tools from the tldr-pages project.
-> Note: The `--language` and `--list` options are not required by the client specification, but most clients implement them.
-> More information: <https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#command-line-interface>.
+> A fast tldr client written in Rust.
+> More information: <https://tealdeer-rs.github.io/tealdeer/>.
 
-- Print the tldr page for a specific command (hint: this is how you got here!):
+- Show the tldr page for a command:
 
 `tldr {{command}}`
 
-- Print the tldr page for a specific subcommand:
+- Show the tldr page for a subcommand:
 
 `tldr {{command}} {{subcommand}}`
 
-- Print the tldr page for a command in the given language (if available, otherwise fall back to English):
+- Show the tldr page for a specific platform:
 
-`tldr {{[-L|--language]}} {{language_code}} {{command}}`
+`tldr --platform {{android|common|freebsd|linux|netbsd|openbsd|osx|sunos|windows}} {{command}}`
 
-- Print the tldr page for a command from a specific platform:
+- Show the tldr page in a specific language:
 
-`tldr {{[-p|--platform]}} {{android|cisco-ios|common|dos|freebsd|linux|netbsd|openbsd|osx|sunos|windows}} {{command}}`
+`tldr --language {{language_code}} {{command}}`
 
-- Update the local cache of tldr pages:
+- Download or update the local page cache:
 
-`tldr {{[-u|--update]}}`
+`tldr --update`
 
-- List all pages for the current platform and `common`:
+- List all pages in the cache:
 
-`tldr {{[-l|--list]}}`
+`tldr --list`
 
-- Browse tldr pages in a terminal window (`fzf` must be available):
+- Render a local markdown file as a tldr page:
 
-`tldr {{[-l|--list]}} | fzf --preview "tldr {1} --color=always" --preview-window=right,70% | xargs tldr`
+`tldr --render {{path/to/file.md}}`
 
-- Print the tldr page for a random command:
+- Show the raw markdown source of a page instead of rendering it:
 
-`tldr {{[-l|--list]}} | shuf {{[-n|--head-count]}} 1 | xargs tldr`
+`tldr --raw {{command}}`
+
+- Show file and directory paths used by tealdeer:
+
+`tldr --show-paths`
+
+- Create an initial config file:
+
+`tldr --seed-config`
+
+- Open a custom page for a command in `$EDITOR` (creates it if it doesn't exist):
+
+`tldr --edit-page {{command}}`
+
+- Open a custom patch for a command in `$EDITOR` (appended to the existing page):
+
+`tldr --edit-patch {{command}}`
+
+- Clear the local cache:
+
+`tldr --clear-cache`

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{self, File},
-    io::{BufReader, Cursor, ErrorKind, Read},
+    io::{Cursor, ErrorKind, Read},
     path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
@@ -277,12 +277,12 @@ impl PageLookupResult {
         self
     }
 
-    /// Create a buffered reader that sequentially reads from the page and the
+    /// Create a reader that sequentially reads from the page and the
     /// patch, as if they were concatenated.
     ///
     /// This will return an error if either the page file or the patch file
     /// cannot be opened.
-    pub fn reader(&self) -> Result<BufReader<Box<dyn Read>>> {
+    pub fn reader(&self) -> Result<Box<dyn Read>> {
         // Open page file
         let page_file = File::open(&self.page_path)
             .with_context(|| format!("Could not open page file at {}", self.page_path.display()))?;
@@ -302,11 +302,11 @@ impl PageLookupResult {
         // the page and patch files and that will read them sequentially,
         // because it avoids the boxing below. However, the performance impact
         // would first need to be shown to be significant using a benchmark.
-        Ok(BufReader::new(if let Some(patch_file) = patch_file_opt {
+        Ok(if let Some(patch_file) = patch_file_opt {
             Box::new(page_file.chain(&b"\n"[..]).chain(patch_file)) as Box<dyn Read>
         } else {
             Box::new(page_file) as Box<dyn Read>
-        }))
+        })
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -40,6 +40,7 @@ pub struct Cache<'a> {
 pub struct PageLookupResult {
     pub page_path: PathBuf,
     pub patch_path: Option<PathBuf>,
+    pub embedded: Option<&'static str>,
 }
 
 impl<'a> Cache<'a> {
@@ -265,10 +266,18 @@ impl<'a> Cache<'a> {
 }
 
 impl PageLookupResult {
+    pub fn with_embedded(content: &'static str) -> Self {
+        Self {
+            page_path: PathBuf::new(),
+            patch_path: None,
+            embedded: Some(content),
+        }
+    }
     pub fn with_page(page_path: PathBuf) -> Self {
         Self {
             page_path,
             patch_path: None,
+            embedded: None,
         }
     }
 
@@ -283,6 +292,11 @@ impl PageLookupResult {
     /// This will return an error if either the page file or the patch file
     /// cannot be opened.
     pub fn reader(&self) -> Result<BufReader<Box<dyn Read>>> {
+        // Open embedded file
+        if let Some(content) = self.embedded {
+            return Ok(BufReader::new(Box::new(Cursor::new(content.as_bytes()))));
+        }
+
         // Open page file
         let page_file = File::open(&self.page_path)
             .with_context(|| format!("Could not open page file at {}", self.page_path.display()))?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -40,7 +40,6 @@ pub struct Cache<'a> {
 pub struct PageLookupResult {
     pub page_path: PathBuf,
     pub patch_path: Option<PathBuf>,
-    pub embedded: Option<&'static str>,
 }
 
 impl<'a> Cache<'a> {
@@ -266,18 +265,10 @@ impl<'a> Cache<'a> {
 }
 
 impl PageLookupResult {
-    pub fn with_embedded(content: &'static str) -> Self {
-        Self {
-            page_path: PathBuf::new(),
-            patch_path: None,
-            embedded: Some(content),
-        }
-    }
     pub fn with_page(page_path: PathBuf) -> Self {
         Self {
             page_path,
             patch_path: None,
-            embedded: None,
         }
     }
 
@@ -292,11 +283,6 @@ impl PageLookupResult {
     /// This will return an error if either the page file or the patch file
     /// cannot be opened.
     pub fn reader(&self) -> Result<BufReader<Box<dyn Read>>> {
-        // Open embedded file
-        if let Some(content) = self.embedded {
-            return Ok(BufReader::new(Box::new(Cursor::new(content.as_bytes()))));
-        }
-
         // Open page file
         let page_file = File::open(&self.page_path)
             .with_context(|| format!("Could not open page file at {}", self.page_path.display()))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,21 @@ use clap::{builder::ArgAction, ArgGroup, Parser};
 
 use crate::types::{ColorOptions, PlatformType};
 
+const AFTER_HELP: &str = r#"To view the user documentation, please visit https://tealdeer-rs.github.io/tealdeer/.
+
+EXAMPLES:
+# View the TLDR page for ip:
+tldr ip
+
+# View a multi-word TLDR page:
+tldr git rebase
+
+# Update TLDR with pages for a specific language:
+tldr --update --language es
+
+# Specify the language for the page:
+tldr tar --language es"#;
+
 // Note: flag names are specified explicitly in clap attributes
 // to improve readability and allow contributors to grep names like "clear-cache"
 #[derive(Parser, Debug)]
@@ -18,7 +33,7 @@ use crate::types::{ColorOptions, PlatformType};
 {usage-heading} {usage}
 
 {all-args}{after-help}",
-    after_help = "To view the user documentation, please visit https://tealdeer-rs.github.io/tealdeer/.",
+    after_help = AFTER_HELP,
     arg_required_else_help = true,
     help_expected = true,
     group = ArgGroup::new("command_or_file").args(&["command", "render"]),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,21 +6,6 @@ use clap::{builder::ArgAction, ArgGroup, Parser};
 
 use crate::types::{ColorOptions, PlatformType};
 
-const AFTER_HELP: &str = r#"To view the user documentation, please visit https://tealdeer-rs.github.io/tealdeer/.
-
-EXAMPLES:
-# View the TLDR page for ip:
-tldr ip
-
-# View a multi-word TLDR page:
-tldr git rebase
-
-# Update TLDR with pages for a specific language:
-tldr --update --language es
-
-# Specify the language for the page:
-tldr tar --language es"#;
-
 // Note: flag names are specified explicitly in clap attributes
 // to improve readability and allow contributors to grep names like "clear-cache"
 #[derive(Parser, Debug)]
@@ -33,7 +18,9 @@ tldr tar --language es"#;
 {usage-heading} {usage}
 
 {all-args}{after-help}",
-    after_help = AFTER_HELP,
+    after_help = "To view the user documentation, please visit https://tealdeer-rs.github.io/tealdeer/.
+
+To view usage examples, run tldr tldr or tldr tealdeer.",
     arg_required_else_help = true,
     help_expected = true,
     group = ArgGroup::new("command_or_file").args(&["command", "render"]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ const APP_INFO: AppInfo = AppInfo {
     name: NAME,
     author: NAME,
 };
+const SELF_PAGE: &str = include_str!("../pages/tldr.md");
 
 /// Clear the cache
 fn clear_cache(cache: Cache, quietly: bool) -> Result<()> {
@@ -407,20 +408,24 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
             );
         }
 
-        let Some(lookup_result) = cache.find_page(&command) else {
-            if !args.quiet {
-                print_warning(
-                    enable_styles,
-                    &format!(
-                        "Page `{}` not found in cache.\n\
-                         Try updating with `tldr --update`, or submit a pull request to:\n\
-                         https://github.com/tldr-pages/tldr",
-                        &command
-                    ),
-                );
-            }
-
-            return Ok(ExitCode::FAILURE);
+        let lookup_result = if command == "tldr" || command == "tealdeer" {
+            PageLookupResult::with_embedded(SELF_PAGE)
+        } else {
+            let Some(result) = cache.find_page(&command) else {
+                if !args.quiet {
+                    print_warning(
+                        enable_styles,
+                        &format!(
+                            "Page `{}` not found in cache.\n\
+                       Try updating with `tldr --update`, or submit a pull request to:\n\
+                       https://github.com/tldr-pages/tldr",
+                            &command
+                        ),
+                    );
+                }
+                return Ok(ExitCode::FAILURE);
+            };
+            result
         };
 
         print_page(&lookup_result, args.raw, enable_styles, args.pager, &config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ compile_error!(
 use std::{
     env,
     fs::create_dir_all,
-    io::{self, IsTerminal},
+    io::{self, Cursor, IsTerminal},
     path::Path,
     process::{Command, ExitCode},
 };
@@ -68,7 +68,8 @@ const APP_INFO: AppInfo = AppInfo {
     name: NAME,
     author: NAME,
 };
-const SELF_PAGE: &str = include_str!("../pages/tldr.md");
+static TEALDEER_PAGE: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/pages/tealdeer.md"));
 
 /// Clear the cache
 fn clear_cache(cache: Cache, quietly: bool) -> Result<()> {
@@ -259,8 +260,8 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
 
     // If a local file was passed in, render it and exit
     if let Some(file) = args.render {
-        let path = PageLookupResult::with_page(file);
-        print_page(&path, args.raw, enable_styles, args.pager, &config)?;
+        let reader = PageLookupResult::with_page(file).reader()?;
+        print_page(reader, args.raw, enable_styles, args.pager, &config)?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -408,8 +409,8 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
             );
         }
 
-        let lookup_result = if command == "tldr" || command == "tealdeer" {
-            PageLookupResult::with_embedded(SELF_PAGE)
+        let reader: Box<dyn io::Read> = if command == "tealdeer" {
+            Box::new(Cursor::new(TEALDEER_PAGE.as_bytes()))
         } else {
             let Some(result) = cache.find_page(&command) else {
                 if !args.quiet {
@@ -425,10 +426,10 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
                 }
                 return Ok(ExitCode::FAILURE);
             };
-            result
+            Box::new(result.reader()?)
         };
 
-        print_page(&lookup_result, args.raw, enable_styles, args.pager, &config)?;
+        print_page(reader, args.raw, enable_styles, args.pager, &config)?;
     }
 
     Ok(ExitCode::SUCCESS)

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ compile_error!(
 use std::{
     env,
     fs::create_dir_all,
-    io::{self, Cursor, IsTerminal},
+    io::{self, IsTerminal},
     path::Path,
     process::{Command, ExitCode},
 };
@@ -268,7 +268,7 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     // The tealdeer page is embedded in the binary, no cache needed
     if command == "tealdeer" {
         print_page(
-            Cursor::new(TEALDEER_PAGE.as_bytes()),
+            TEALDEER_PAGE.as_bytes(),
             args.raw,
             enable_styles,
             args.pager,

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,6 +265,18 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     }
 
+    // The tealdeer page is embedded in the binary, no cache needed
+    if command == "tealdeer" {
+        print_page(
+            Cursor::new(TEALDEER_PAGE.as_bytes()),
+            args.raw,
+            enable_styles,
+            args.pager,
+            &config,
+        )?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
     if let Some(platforms) = args.platforms {
         config.search.platforms = platforms;
         if !config.search.platforms.contains(&PlatformType::Common) {
@@ -409,27 +421,28 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
             );
         }
 
-        let reader: Box<dyn io::Read> = if command == "tealdeer" {
-            Box::new(Cursor::new(TEALDEER_PAGE.as_bytes()))
-        } else {
-            let Some(result) = cache.find_page(&command) else {
-                if !args.quiet {
-                    print_warning(
-                        enable_styles,
-                        &format!(
-                            "Page `{}` not found in cache.\n\
-                       Try updating with `tldr --update`, or submit a pull request to:\n\
-                       https://github.com/tldr-pages/tldr",
-                            &command
-                        ),
-                    );
-                }
-                return Ok(ExitCode::FAILURE);
-            };
-            Box::new(result.reader()?)
+        let Some(result) = cache.find_page(&command) else {
+            if !args.quiet {
+                print_warning(
+                    enable_styles,
+                    &format!(
+                        "Page `{}` not found in cache.\n\
+                         Try updating with `tldr --update`, or submit a pull request to:\n\
+                         https://github.com/tldr-pages/tldr",
+                        &command
+                    ),
+                );
+            }
+            return Ok(ExitCode::FAILURE);
         };
 
-        print_page(reader, args.raw, enable_styles, args.pager, &config)?;
+        print_page(
+            result.reader()?,
+            args.raw,
+            enable_styles,
+            args.pager,
+            &config,
+        )?;
     }
 
     Ok(ExitCode::SUCCESS)

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,12 +1,11 @@
 //! Functions for printing pages to the terminal
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
 
 use anyhow::{Context, Result};
 use yansi::Paint;
 
 use crate::{
-    cache::PageLookupResult,
     config::{Config, StyleConfig},
     formatter::{highlight_lines, PageSnippet},
     line_iterator::LineIterator,
@@ -30,14 +29,13 @@ fn configure_pager(enable_styles: bool) {
 
 /// Print page by path
 pub fn print_page(
-    lookup_result: &PageLookupResult,
+    reader: impl Read,
     enable_markdown: bool,
     enable_styles: bool,
     use_pager: bool,
     config: &Config,
 ) -> Result<()> {
-    // Create reader from file(s)
-    let reader = lookup_result.reader()?;
+    let reader = BufReader::new(reader);
 
     // Configure pager if applicable
     if use_pager || config.display.use_pager {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -301,6 +301,16 @@ fn test_missing_cache() {
         .stderr(contains("Page cache not found. Please run `tldr --update`"));
 }
 
+#[test]
+fn test_tealdeer_page_works_without_cache() {
+    TestEnv::new()
+        .command()
+        .args(["tealdeer"])
+        .assert()
+        .success()
+        .stdout(contains("for your installed tealdeer version"));
+}
+
 #[cfg_attr(feature = "ignore-online-tests", ignore = "online test")]
 #[test]
 fn test_update_cache_default_features() {


### PR DESCRIPTION
Adds examples section to the bottom:

```
To view the user documentation, please visit https://tealdeer-rs.github.io/tealdeer/.

EXAMPLES:
# View the TLDR page for ip:
tldr ip

# View a multi-word TLDR page:
tldr git rebase

# Update TLDR with pages for a specific language:
tldr --update --language es

# Specify the language for the page:
tldr tar --language es
```


Fixes #218.