### PR TITLE
Respect --quiet when cache is missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -358,20 +358,22 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     } else if args.list || !command.is_empty() {
         // Cache is needed for these commands to work
         let Some(cache) = Cache::open(cache_config)? else {
-            print_error(
-                enable_styles,
-                &anyhow::anyhow!(
-                    "Page cache not found. Please run `tldr --update` to download the cache."
-                ),
-            );
-            println!("\nNote: You can optionally enable automatic cache updates by adding the");
-            println!("following config to your config file:\n");
-            println!("  [updates]");
-            println!("  auto_update = true\n");
-            println!("The path to your config file can be looked up with `tldr --show-paths`.");
-            println!("To create an initial config file, use `tldr --seed-config`.\n");
-            println!("You can find more tips and tricks in our docs:\n");
-            println!("  https://tealdeer-rs.github.io/tealdeer/config_updates.html");
+            if !args.quiet {
+                print_error(
+                    enable_styles,
+                    &anyhow::anyhow!(
+                        "Page cache not found. Please run `tldr --update` to download the cache."
+                    ),
+                );
+                println!("\nNote: You can optionally enable automatic cache updates by adding the");
+                println!("following config to your config file:\n");
+                println!("  [updates]");
+                println!("  auto_update = true\n");
+                println!("The path to your config file can be looked up with `tldr --show-paths`.");
+                println!("To create an initial config file, use `tldr --seed-config`.\n");
+                println!("You can find more tips and tricks in our docs:\n");
+                println!("  https://tealdeer-rs.github.io/tealdeer/config_updates.html");
+            }
 
             return Ok(ExitCode::FAILURE);
         };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -302,6 +302,25 @@ fn test_missing_cache() {
 }
 
 #[test]
+fn test_quiet_missing_cache() {
+    TestEnv::new()
+        .command()
+        .args(["sl", "--quiet"])
+        .assert()
+        .failure()
+        .stdout(is_empty())
+        .stderr(is_empty());
+
+    TestEnv::new()
+        .command()
+        .args(["--list", "--quiet"])
+        .assert()
+        .failure()
+        .stdout(is_empty())
+        .stderr(is_empty());
+}
+
+#[test]
 fn test_tealdeer_page_works_without_cache() {
     TestEnv::new()
         .command()


### PR DESCRIPTION
Related to #268.

With no local cache, `tldr --list --quiet` and `tldr <cmd> --quiet` still printed the missing-cache diagnostics and follow-up guidance. That made `--quiet` noisy in shell-completion and scripting paths even though the command was already returning a failure exit code.

This keeps the failure exit code, but skips both the stderr error and the stdout guidance when `--quiet` is set. A regression test covers both `sl --quiet` and `--list --quiet` with an empty cache.

Validation:
- `cargo test -q --manifest-path Cargo.toml test_quiet_missing_cache -- --nocapture`
- `cargo test -q --manifest-path Cargo.toml test_missing_cache -- --nocapture`
- `cargo test -q --manifest-path Cargo.toml test_quiet_old_cache -- --nocapture`
- `cargo test -q --manifest-path Cargo.toml`
- `cargo fmt --check --manifest-path Cargo.toml`