### PR TITLE
fix: fully respect --quiet flag and route tip messages to stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,14 +364,14 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
                     "Page cache not found. Please run `tldr --update` to download the cache."
                 ),
             );
-            println!("\nNote: You can optionally enable automatic cache updates by adding the");
-            println!("following config to your config file:\n");
-            println!("  [updates]");
-            println!("  auto_update = true\n");
-            println!("The path to your config file can be looked up with `tldr --show-paths`.");
-            println!("To create an initial config file, use `tldr --seed-config`.\n");
-            println!("You can find more tips and tricks in our docs:\n");
-            println!("  https://tealdeer-rs.github.io/tealdeer/config_updates.html");
+            eprintln!("\nNote: You can optionally enable automatic cache updates by adding the");
+            eprintln!("following config to your config file:\n");
+            eprintln!("  [updates]");
+            eprintln!("  auto_update = true\n");
+            eprintln!("The path to your config file can be looked up with `tldr --show-paths`.");
+            eprintln!("To create an initial config file, use `tldr --seed-config`.\n");
+            eprintln!("You can find more tips and tricks in our docs:\n");
+            eprintln!("  https://tealdeer-rs.github.io/tealdeer/config_updates.html");
 
             return Ok(ExitCode::FAILURE);
         };
@@ -405,7 +405,7 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     // Show command from cache
     if !command.is_empty() {
         // TODO: Remove this check 1 year after version 1.7.0 was released
-        if cache.old_custom_pages_exist()? {
+        if !args.quiet && cache.old_custom_pages_exist()? {
             print_warning(
                 enable_styles,
                 &format!(


### PR DESCRIPTION
## Problem

Fixes #268

Two related issues with diagnostic output:

### 1. Cache-not-found tip text goes to stdout

When the page cache is missing and `tldr --list` (or a page lookup) is run, the error is correctly sent to stderr via `print_error`, but the follow-up tip block uses `println!`, sending instructional text to **stdout**:

```
Note: You can optionally enable automatic cache updates by adding the
following config to your config file:
  ...
```

This causes the text to appear inline in shell completion output (e.g. `tldr t<Tab>` shows the tips mid-completion). All diagnostic output should go to stderr.

### 2. Old custom-pages deprecation warning ignores `--quiet`

The warning for old custom-pages naming convention (`<name>.page` → `<name>.page.md`) was not gated by `!args.quiet`, so it printed even when the user explicitly requested silence. Every other warning site in the same file already checks `args.quiet`.

## Fix

1. Changed the 8 `println!` calls in the cache-not-found branch to `eprintln!`.
2. Added `!args.quiet` guard to the old custom-pages deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)