### PR TITLE
Added AI Policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ To run lints:
     $ cargo clean && cargo clippy
 
 
+### AI Policy
+
+Using AI is generally discouraged. However, if it is used as part of a contribution, the contributor must:
+
+1. Clearly mark what parts (if any) of a contribution were created with the help of AI tools. This includes issue and pull request comments.
+2. Check all output of AI tools before sharing it with others in the Tealdeer project.
+3. Not post slop, spam, or low quality contributions.
+4. Leave small or easy tasks to new contributors who want to learn without the use of AI. This is to maintain the presence of the `good-first-issue` tag.
+5. Be respectful of everyone's time: maintainers and other contributors will be reviewing your PRs.
+
+
 ## MSRV (Minimally Supported Rust Version)
 
 When publishing a tealdeer release, the Rust version required to build it

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ To run lints:
 
 ### AI Policy
 
-Using AI is generally discouraged. However, if it is used as part of a contribution, the contributor must:
+Using AI is generally discouraged. However, if it is used as part of a contribution, the contributor MUST:
 
 1. Clearly mark what parts (if any) of a contribution were created with the help of AI tools. This includes issue and pull request comments.
-2. Check all output of AI tools before sharing it with others in the Tealdeer project.
-3. Not post slop, spam, or low quality contributions.
+2. Check all output of AI tools before sharing it with others in the tealdeer project.
+3. Not post slop, spam, or low quality contributions. This includes pull request descriptions and comments with excessive text and markdown flair.
 4. Leave small or easy tasks to new contributors who want to learn without the use of AI. This is to maintain the presence of the `good-first-issue` tag.
-5. Be respectful of everyone's time: maintainers and other contributors will be reviewing your PRs.
+5. Be respectful of everyone's time: *maintainers and other contributors will be reviewing your PRs.* 
 
 
 ## MSRV (Minimally Supported Rust Version)


### PR DESCRIPTION
Addresses #479, and adds a section for an AI policy based on what is outlined by @niklasmohrin in that issue. The AI Policy is located below the "Development" section.

Lmk if any wording needs to change. I'm using "must" in the AI policy in the way that RFCs do.